### PR TITLE
Fix validate type

### DIFF
--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -49,6 +49,27 @@ namespace NJsonSchema.Tests.Validation
         }
 
         [TestMethod]
+        public void When_property_matches_one_of_the_types_then_it_should_succeed()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.Object;
+            schema.Properties["Foo"] = new JsonProperty
+            {
+                Type = JsonObjectType.Number | JsonObjectType.Null
+            };
+
+            var token = new JObject();
+            token["Foo"] = new JValue(5);
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+
+        [TestMethod]
         public void When_optional_property_is_missing_then_it_should_succeed()
         {
             //// Arrange

--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -70,6 +70,25 @@ namespace NJsonSchema.Tests.Validation
         }
 
         [TestMethod]
+        public void When_property_type_not_specified_then_anything_should_succeed()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.Object;
+            schema.Properties["Foo"] = new JsonProperty();
+            schema.Properties["Bar"] = new JsonProperty();
+
+            var token = new JObject();
+            token["Foo"] = new JValue(5);
+            token["Bar"] = new JValue("Bar");
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+
+        [TestMethod]
         public void When_optional_property_is_missing_then_it_should_succeed()
         {
             //// Arrange

--- a/src/NJsonSchema/Validation/ValidationErrorKind.cs
+++ b/src/NJsonSchema/Validation/ValidationErrorKind.cs
@@ -126,6 +126,24 @@ namespace NJsonSchema.Validation
         TooManyProperties,
 
         /// <summary>There are too few properties in the tuple. </summary>
-        TooFewProperties
+        TooFewProperties,
+
+        /// <summary>A string is not expected according to the type. </summary>
+        StringNotExpected,
+
+        /// <summary>A boolean is not expected according to the type. </summary>
+        BooleanNotExpected,
+
+        /// <summary>An object is not expected according to the type. </summary>
+        ObjectNotExpected,
+
+        /// <summary>A null value is not expected according to the type. </summary>
+        NullNotExpected,
+
+        /// <summary>A number is not expected according to the type. </summary>
+        NumberNotExpected,
+
+        /// <summary>A non-integral number is not expected according to the type. </summary>
+        NonIntegralNumberNotExpected
     }
 }


### PR DESCRIPTION
Fix for issue #29.

Summary: 

The Validate{String,Number,Boolean,Null,Object} methods validate the token *only* if the method applies the actual type of the token. This validation includes checking whether this actual type is admissible according to the Type of the schema. This simplifies the ValidateType method.
The ValidateInteger method is subsumed by the ValidateNumber method and has been removed.

For downwards compatibility, a case distinction is made for the error that is reported when the actual type is not admisible. If the schema allows only one type, the same "XyzExpected" error is reported as was the case before.  If the schema allows more than one type, one can not realy say what was expected and, hence, a "XyzNotExpected" error is reported based on the type of the actual value.