### PR TITLE
Obsoleting Base64 format

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharpGeneratorTests.cs
@@ -122,6 +122,35 @@ namespace NJsonSchema.CodeGeneration.Tests
             //// Assert
             Assert.IsTrue(output.Contains(@"/// <summary>PropertyDesc.</summary>"));
         }
+
+        [TestMethod]
+        public void Can_generate_type_from_string_property_with_byte_format()
+        {
+            // Arrange
+            var schema = JsonSchema4.FromType<File>();
+            var generator = new CSharpGenerator(schema);
+
+            // Act
+            var output = generator.GenerateFile();
+
+            // Assert
+            Assert.IsTrue(output.Contains("public byte[] Content"));
+        }
+
+        [TestMethod]
+        public void Can_generate_type_from_string_property_with_base64_format()
+        {
+            // Arrange
+            var schema = JsonSchema4.FromType<File>();
+            schema.Properties["Content"].Format = "base64";
+            var generator = new CSharpGenerator(schema);
+
+            // Act
+            var output = generator.GenerateFile();
+
+            // Assert
+            Assert.IsTrue(output.Contains("public byte[] Content"));
+        }
         
         private static CSharpGenerator CreateGenerator()
         {

--- a/src/NJsonSchema.CodeGeneration.Tests/Models/File.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/Models/File.cs
@@ -1,0 +1,7 @@
+﻿namespace NJsonSchema.CodeGeneration.Tests.Models
+{
+    public class File
+    {
+        public byte[] Content { get; set; } 
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Address.cs" />
     <Compile Include="EnumGenerationTests.cs" />
+    <Compile Include="Models\File.cs" />
     <Compile Include="Models\Gender.cs" />
     <Compile Include="Models\Person.cs" />
     <Compile Include="Models\Teacher.cs" />

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpTypeResolver.cs
@@ -80,7 +80,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 if (schema.Format == JsonFormatStrings.Guid)
                     return isNullable ? "Guid?" : "Guid";
 
-                if (schema.Format == JsonFormatStrings.Base64)
+#pragma warning disable 618 // used to resolve type from schemas generated with previous version of the library
+                if (schema.Format == JsonFormatStrings.Base64 || schema.Format == JsonFormatStrings.Byte)
+#pragma warning restore 618
                     return "byte[]";
 
                 if (schema.IsEnumeration)

--- a/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
@@ -32,7 +32,7 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.AreEqual(JsonObjectType.String, schema.Properties["Bytes"].Type);
-            Assert.AreEqual(JsonFormatStrings.Base64, schema.Properties["Bytes"].Format);
+            Assert.AreEqual(JsonFormatStrings.Byte, schema.Properties["Bytes"].Format);
         }
 
         [TestMethod]

--- a/src/NJsonSchema.Tests/Validation/FormatBase64Tests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatBase64Tests.cs
@@ -30,6 +30,26 @@ namespace NJsonSchema.Tests.Validation
         }
 
         [TestMethod]
+        public void Validation_should_fail_if_string_is_not_byte_formatted()
+        {
+            //// Arrange
+            var schema = new JsonSchema4
+                         {
+                             Type = JsonObjectType.String,
+                             Format = JsonFormatStrings.Byte
+                         };
+
+            var token = new JValue("invalid");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual(ValidationErrorKind.Base64Expected, errors.Single().Kind);
+        }
+
+        [TestMethod]
         public void Validation_should_succeed_if_string_is_base64_formatted_with_trailing_equals()
         {
             //// Arrange
@@ -37,6 +57,26 @@ namespace NJsonSchema.Tests.Validation
                          {
                              Type = JsonObjectType.String,
                              Format = JsonFormatStrings.Base64
+                         };
+
+            var value = Convert.ToBase64String(new byte[] { 101, 22, 87, 25 });
+            var token = new JValue(value);
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count);
+        }
+
+        [TestMethod]
+        public void Validation_should_succeed_if_string_is_byte_formatted_with_trailing_equals()
+        {
+            //// Arrange
+            var schema = new JsonSchema4
+                         {
+                             Type = JsonObjectType.String,
+                             Format = JsonFormatStrings.Byte
                          };
 
             var value = Convert.ToBase64String(new byte[] { 101, 22, 87, 25 });
@@ -67,6 +107,45 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(0, errors.Count);
+        }
+
+        [TestMethod]
+        public void Validation_should_succeed_if_string_is_byte_formatted_without_trailing_equals()
+        {
+            //// Arrange
+            var schema = new JsonSchema4
+                         {
+                             Type = JsonObjectType.String,
+                             Format = JsonFormatStrings.Byte
+                         };
+
+            var value = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+            var token = new JValue(value);
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count);
+        }
+
+        [TestMethod]
+        public void Numeric_type_should_not_trigger_validation_if_has_byte_format()
+        {
+            //// Arrange
+            var numericSchema = new JsonSchema4
+                                {
+                                    Type = JsonObjectType.Integer,
+                                    Format = JsonFormatStrings.Byte
+                                };
+
+            var token = new JValue(1);
+
+            //// Act
+            var numericErrors = numericSchema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, numericErrors.Count);
         }
     }
 }

--- a/src/NJsonSchema/JsonFormatStrings.cs
+++ b/src/NJsonSchema/JsonFormatStrings.cs
@@ -35,9 +35,11 @@ namespace NJsonSchema
         public const string IpV6 = "ipv6";
 
         /// <summary>Format for binary data encoded with Base64.</summary>
+        /// <remarks>Should not be used. Prefer using Byte property of <see cref="JsonFormatStrings"/></remarks>
+        [Obsolete("Now made redundant. Use \"byte\" instead")]
         public const string Base64 = "base64";
 
-        /// <summary>Format for a byte.</summary>
+        /// <summary>Format for a byte if used with numeric type or for base64 encoded value otherwise.</summary>
         public const string Byte = "byte";
 
         /// <summary>Format for a hostname (DNS name).</summary>

--- a/src/NJsonSchema/JsonObjectTypeDescription.cs
+++ b/src/NJsonSchema/JsonObjectTypeDescription.cs
@@ -56,7 +56,7 @@ namespace NJsonSchema
                 return new JsonObjectTypeDescription(JsonObjectType.Integer, true, false, JsonFormatStrings.Byte);
 
             if (type == typeof(byte[]))
-                return new JsonObjectTypeDescription(JsonObjectType.String, false, false, JsonFormatStrings.Base64);
+                return new JsonObjectTypeDescription(JsonObjectType.String, false, false, JsonFormatStrings.Byte);
 
             if (IsDictionaryType(type))
                 return new JsonObjectTypeDescription(JsonObjectType.Object, false, true);

--- a/src/NJsonSchema/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/JsonSchemaValidator.cs
@@ -222,7 +222,9 @@ namespace NJsonSchema
                                 errors.Add(new ValidationError(ValidationErrorKind.HostnameExpected, propertyName, propertyPath));
                         }
 
-                        if (_schema.Format == JsonFormatStrings.Base64)
+#pragma warning disable 618 //Base64 check is used for backward compatibility
+                        if (_schema.Format == JsonFormatStrings.Byte || _schema.Format == JsonFormatStrings.Base64)
+#pragma warning restore 618
                         {
                             var isBase64 = (value.Length % 4 == 0) && Regex.IsMatch(value, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
 


### PR DESCRIPTION
According to our discussion made `base64` format obsolete and replaced it with `byte`.