### PR TITLE
TypeRaw property changed to deserialize without using JsonConvert.DeserializeObject

### DIFF
--- a/src/NJsonSchema/JsonSchema4.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema4.Serialization.cs
@@ -117,10 +117,15 @@ namespace NJsonSchema
             {
                 if (value is JArray)
                     Type = ((JArray)value).Aggregate(JsonObjectType.None, (type, token) => type | ConvertStringToObjectType(token.ToString()));
-                else if (value != null)
-                    Type = ConvertStringToObjectType(value.ToString());
                 else
-                    Type = JsonObjectType.None;
+                {
+                    // Section 5.5.2:
+                    // http://json-schema.org/latest/json-schema-validation.html#anchor79
+                    // "type" must be either string or array.
+                    // At this point we expect a valid string
+                    // with one of the 7 primitive names, anything else is invalid.
+                    Type = ConvertStringToObjectType( value as string );
+                }
             }
         }
 

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -556,8 +556,29 @@ namespace NJsonSchema
 
         private static JsonObjectType ConvertStringToObjectType(string value)
         {
-            // TODO: Improve performance
-            return JsonConvert.DeserializeObject<JsonObjectType>("\"" + value + "\"");
+            // Section 3.5:
+            // http://json-schema.org/latest/json-schema-core.html#anchor8
+            // The string must be one of the 7 primitive types
+
+            switch( value )
+            {
+                case "array":
+                    return JsonObjectType.Array;
+                case "boolean"  :
+                    return JsonObjectType.Boolean;
+                case "integer"  :
+                    return JsonObjectType.Integer;
+                case "number"   :
+                    return JsonObjectType.Number;
+                case "null"     :
+                    return JsonObjectType.Null;
+                case "object"   :
+                    return JsonObjectType.Object;
+                case "string"   :
+                    return JsonObjectType.String;
+                default:
+                    return JsonObjectType.None;
+            }
         }
 
         private void Initialize()


### PR DESCRIPTION
Deserializing the `TypeRaw` property choses from the 7 allowed primitive types directly, instead of using DeserializeObject.

Thanks for the lib :+1: 