### PR TITLE
Fixes CSharp CodeGeneration Class t4 template

### DIFF
--- a/src/NJsonSchema.CodeGeneration/CSharp/Templates/ClassTemplate.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/Templates/ClassTemplate.cs
@@ -147,7 +147,14 @@ if(property.HasDescription){
             
             #line default
             #line hidden
-            this.Write("\", Required = <property.Required>)]\r\n");
+            this.Write("\", Required = ");
+            
+            #line 12 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration\CSharp\Templates\ClassTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(property.Required));
+            
+            #line default
+            #line hidden
+            this.Write(")]\r\n");
             
             #line 13 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration\CSharp\Templates\ClassTemplate.tt"
 if(property.IsStringEnum){

--- a/src/NJsonSchema.CodeGeneration/CSharp/Templates/ClassTemplate.tt
+++ b/src/NJsonSchema.CodeGeneration/CSharp/Templates/ClassTemplate.tt
@@ -9,7 +9,7 @@
 
 <#foreach(var property in Model.Properties){#>
 <#if(property.HasDescription){#>    /// <summary><#=property.Description#></summary>
-<#}#>    [JsonProperty("<#=property.Name#>", Required = <property.Required>)]
+<#}#>    [JsonProperty("<#=property.Name#>", Required = <#=property.Required#>)]
 <#if(property.IsStringEnum){#>    [JsonConverter(typeof(StringEnumConverter))]
 <#}#>
     public <#=property.Type#> <#=property.PropertyName#><#if(!Model.Inpc){#> { get; set; }<#if(property.HasDefaultValue){#> = <#=property.DefaultValue#>;<#}#>


### PR DESCRIPTION
A typo is causing the CSharp Class t4 template to output invalid C# code.