### PR TITLE
Test and a fix related to default boolean values in CS code

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -8,6 +8,25 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     [TestClass]
     public class CSharpGeneratorTests
     {
+
+        [TestMethod]
+        public void When_property_has_boolean_default_it_is_reflected_in_the_poco()
+        {
+            var schema = @"{'properties': {
+                                'boolWithDefault': {
+                                    'type': 'boolean',
+                                    'default': false
+                                 }
+                             }}";
+
+            var s = NJsonSchema.JsonSchema4.FromJson(schema);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var gen = new CSharpGenerator(s, settings);
+            var output = gen.GenerateFile();
+
+            Assert.IsTrue(output.Contains("public bool BoolWithDefault { get; set; } = false"));
+        }
+
         [TestMethod]
         public void When_namespace_is_set_then_it_should_appear_in_output()
         {

--- a/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
@@ -14,9 +14,10 @@ namespace NJsonSchema.CodeGeneration.Models
 
             if (property.Type.HasFlag(JsonObjectType.String))
                 return "\"" + property.Default + "\"";
+            else if (property.Type.HasFlag(JsonObjectType.Boolean))
+                return property.Default.ToString().ToLower();
             else if (property.Type.HasFlag(JsonObjectType.Integer) ||
                      property.Type.HasFlag(JsonObjectType.Number) ||
-                     property.Type.HasFlag(JsonObjectType.Boolean) ||
                      property.Type.HasFlag(JsonObjectType.Integer))
                 return property.Default.ToString();
             return null;


### PR DESCRIPTION
Hey! Found a minor issue in generated code when schema contains boolean fields that have default values. 

Boolean default values are generated as 'True|False', which is not valid cs.
Lowcasing fixes the issue. Typescript also seems to use lowcase boolean literals.

This pull request contains a test that surfaces the issue for generated cs, and provides a fix that allows the test to pass.