### PR TITLE
Array ref support

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -10,6 +10,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     {
 
         [TestMethod]
+        [Ignore]
         public void WhenSchemaContainsRefToDefinitionThatRefsAnotherDefinition_ThenResultShouldContainCorrectTargetRefType()
         {
             /// Arrange

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -10,6 +10,48 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     {
 
         [TestMethod]
+        public void WhenSchemaContainsRefToDefinitionThatRefsAnotherDefinition_ThenResultShouldContainCorrectTargetRefType()
+        {
+            /// Arrange
+            var schemaJson = @"{
+                                 'typeName': 'foo',
+                                 'type': 'object',
+                                 'definitions': {
+                                    'pRef': {
+                                            'type': 'object',
+                                            'properties' : {
+                                                'pRef2': {
+                                                    '$ref': '#/definitions/pRef2'
+                                                },
+                                            }
+                                     },
+                                     'pRef2' : {
+                                            'type': 'string'  
+                                      } 
+                                 },
+                                 'properties': { 
+                                    'pRefs': {
+                                        'type': 'array',
+                                        'items': {
+                                            '$ref': '#/definitions/pRef'
+                                        }
+                                     } 
+                                }
+                               }";
+
+            var schema = NJsonSchema.JsonSchema4.FromJson(schemaJson);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco };
+            var gen = new CSharpGenerator(schema, settings);
+
+            /// Act
+            var output = gen.GenerateFile();
+
+            /// Assert
+            Assert.IsTrue(output.Contains("public ObservableCollection<PRef>"));
+
+        }
+
+        [TestMethod]
         public void When_property_has_boolean_default_it_is_reflected_in_the_poco()
         {
             var schema = @"{'properties': {

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.Tests.Models;
+using System;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {
@@ -10,12 +11,12 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     {
 
         [TestMethod]
-        [Ignore]
+        //[Ignore]
         public void WhenSchemaContainsRefToDefinitionThatRefsAnotherDefinition_ThenResultShouldContainCorrectTargetRefType()
         {
             /// Arrange
             var schemaJson = @"{
-                                 'typeName': 'foo',
+                                 'x-typeName': 'foo',
                                  'type': 'object',
                                  'definitions': {
                                     'pRef': {
@@ -48,7 +49,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var output = gen.GenerateFile();
 
             /// Assert
-            Assert.IsTrue(output.Contains("public ObservableCollection<PRef>"));
+            Assert.IsTrue(output.Contains("public ObservableCollection<pRef>"));
 
         }
 


### PR DESCRIPTION
This test surfaces an issue where Anonymous types are generated for a ref type that is well defined.

i.e. if a type ref is used, i would expect the ref type be generated as it's own class and the generated code should contain a typed collection of type ref type.