### PR TITLE
allOf support (simple)

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -8,6 +8,54 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     [TestClass]
     public class CSharpGeneratorTests
     {
+        [TestMethod]
+        public void multiple_refs_in_all_of_should_expand_to_single_def()
+        {
+            var schema = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'id': 'http://some.domain.com/foo.json',
+                'type': 'object',
+                'additionalProperties': false,
+                'definitions': {
+                    'tRef1': {
+                        'type': 'object',
+                        'properties': {
+                            'val1': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef2': {
+                        'type': 'object',
+                        'properties': {
+                            'val2': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef3': {
+                        'type': 'object',
+                        'properties': {
+                            'val3': {
+                                'type': 'string',
+                            }
+                        }
+                    }
+                },
+                'tAgg': {
+                    'allOf': [
+                        {'$ref': '#/definitions/tRef1'},
+                        {'$ref': '#/definitions/tRef2'},
+                        {'$ref': '#/definitions/tRef3'}
+                    ]
+                }
+            }";
+            var s = NJsonSchema.JsonSchema4.FromJson(schema);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var gen = new CSharpGenerator(s, settings);
+            var output = gen.GenerateFile();
+            System.Console.WriteLine(output);
+        } 
 
         [TestMethod]
         public void When_property_has_boolean_default_it_is_reflected_in_the_poco()

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     public class CSharpGeneratorTests
     {
         [TestMethod]
-        public void multiple_refs_in_all_of_should_expand_to_single_def()
+        public void multiple_refs_in_all_of_should_expand_to_single_def_if_is_flatten_all_of_setting_is_set()
         {
             var schema = @"{
                 '$schema': 'http://json-schema.org/draft-04/schema#',
@@ -54,7 +54,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
                 }
             }";
             var s = NJsonSchema.JsonSchema4.FromJson(schema);
-            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", IsFlattenAllOf=true};
             var gen = new CSharpGenerator(s, settings);
             var output = gen.GenerateFile();
 

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -14,6 +14,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var schema = @"{
                 '$schema': 'http://json-schema.org/draft-04/schema#',
                 'id': 'http://some.domain.com/foo.json',
+                'x-typeName': 'foo',
                 'type': 'object',
                 'additionalProperties': false,
                 'definitions': {
@@ -42,12 +43,14 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
                         }
                     }
                 },
-                'tAgg': {
-                    'allOf': [
-                        {'$ref': '#/definitions/tRef1'},
-                        {'$ref': '#/definitions/tRef2'},
-                        {'$ref': '#/definitions/tRef3'}
-                    ]
+                'properties' : {
+                    'tAgg': {
+                        'allOf': [
+                            {'$ref': '#/definitions/tRef1'},
+                            {'$ref': '#/definitions/tRef2'},
+                            {'$ref': '#/definitions/tRef3'}
+                        ]
+                    }
                 }
             }";
             var s = NJsonSchema.JsonSchema4.FromJson(schema);
@@ -55,6 +58,13 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var gen = new CSharpGenerator(s, settings);
             var output = gen.GenerateFile();
             System.Console.WriteLine(output);
+
+            /// Assert
+            Assert.IsTrue(output.Contains("public partial class tAgg"));
+            Assert.IsTrue(output.Contains("public string Val1 { get; set; }"));
+            Assert.IsTrue(output.Contains("public string Val2 { get; set; }"));
+            Assert.IsTrue(output.Contains("public string Val3 { get; set; }"));
+
         } 
 
         [TestMethod]

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -57,7 +57,6 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
             var gen = new CSharpGenerator(s, settings);
             var output = gen.GenerateFile();
-            System.Console.WriteLine(output);
 
             /// Assert
             Assert.IsTrue(output.Contains("public partial class tAgg"));

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
@@ -73,6 +73,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
         {
             var typeName = _schema.GetTypeName(Settings.TypeNameGenerator);
 
+            // if schema is a allOf schema, expand properties to 
+
+
             if (string.IsNullOrEmpty(typeName))
                 typeName = fallbackTypeName;
 
@@ -84,9 +87,18 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         private TypeGeneratorResult GenerateClass(string typeName)
         {
+
             var properties = _schema.Properties.Values
                 .Select(property => new PropertyModel(property, _resolver, Settings))
                 .ToList();
+
+            if (_schema.AllOf.Count > 1)
+            {
+                var allOfProperties = _schema.AllOf
+                    .SelectMany(s => s.ActualSchema.Properties.Values.Select(property => new PropertyModel(property, _resolver, Settings)))
+                   .ToList();
+                properties.AddRange(allOfProperties);
+            }
 
             var model = new ClassTemplateModel(typeName, Settings, _resolver, _schema, properties); 
 

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
@@ -92,7 +92,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 .Select(property => new PropertyModel(property, _resolver, Settings))
                 .ToList();
 
-            if (_schema.AllOf.Count > 1)
+            if (_schema.AllOf.Count > 2)
             {
                 var allOfProperties = _schema.AllOf
                     .SelectMany(s => s.ActualSchema.Properties.Values.Select(property => new PropertyModel(property, _resolver, Settings)))

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
@@ -72,13 +72,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
         public override TypeGeneratorResult GenerateType(string fallbackTypeName)
         {
             var typeName = _schema.GetTypeName(Settings.TypeNameGenerator);
-
-            // if schema is a allOf schema, expand properties to 
-
-
             if (string.IsNullOrEmpty(typeName))
                 typeName = fallbackTypeName;
-
             if (_schema.IsEnumeration)
                 return GenerateEnum(typeName);
             else
@@ -92,7 +87,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 .Select(property => new PropertyModel(property, _resolver, Settings))
                 .ToList();
 
-            if (_schema.AllOf.Count > 2)
+            if (_resolver.Settings.IsFlattenAllOf && _schema.AllOf.Count > 1)
             {
                 var allOfProperties = _schema.AllOf
                     .SelectMany(s => s.ActualSchema.Properties.Values.Select(property => new PropertyModel(property, _resolver, Settings)))

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGeneratorSettings.cs
@@ -39,5 +39,10 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the CSharp class style (default: 'Poco').</summary>
         public CSharpClassStyle ClassStyle { get; set; }
+
+        /// <summary>
+        ///  Flatten allOf entity properties into the parent type
+        /// </summary>
+        public bool IsFlattenAllOf { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration/CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/Models/ClassTemplateModel.cs
@@ -47,7 +47,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         {
             get
             {
-                if (HasInheritance)
+                if (HasInheritance && !_settings.IsFlattenAllOf)
                     return ": " + BaseClass + (_settings.ClassStyle == CSharpClassStyle.Inpc ? ", INotifyPropertyChanged" : "");
                 else
                     return _settings.ClassStyle == CSharpClassStyle.Inpc ? ": INotifyPropertyChanged" : "";


### PR DESCRIPTION
Hey,

Ended up adding a simple allOf support for CS codegen. The idea is to expand any allOf definitions into the aggregate type API. 

This could probably be developed further by generating interfaces for the types in the aggregates, and having the aggregate type implement those interfaces. It also might be nice if aggregate type would actually wrap real instances of the types making up the aggregate - and provide ways for constructing the aggregate using these instances. 

However, i'll experiment with this as the first step to get some code generated for the aggregates. Seems like the api resulting from this simple implementation should not break even more features like the above are added later.
