### PR TITLE
Array empty schema support

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -3,13 +3,30 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.Tests.Models;
-using System;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {
     [TestClass]
     public class CSharpGeneratorTests
     {
+
+        [TestMethod]
+        [Ignore]
+        public void array_with_no_items_present_should_be_considered_to_have_items_with_empty_schema_content()
+        {
+            var schema = @"{
+                                'properties': {
+                                    'emptySchema': { 'type': 'array' }
+                                }
+                            }";
+            var s = NJsonSchema.JsonSchema4.FromJson(schema);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var gen = new CSharpGenerator(s, settings);
+            var output = gen.GenerateFile();
+
+            // assert once we know what kind of code is generated: List<dynamic>? 
+        }
+
         [TestMethod]
         public void multiple_refs_in_all_of_should_expand_to_single_def()
         {

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -59,7 +59,6 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
             var gen = new CSharpGenerator(s, settings);
             var output = gen.GenerateFile();
-            System.Console.WriteLine(output);
 
             /// Assert
             Assert.IsTrue(output.Contains("public partial class tAgg"));

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -10,6 +10,54 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     [TestClass]
     public class CSharpGeneratorTests
     {
+        [TestMethod]
+        public void multiple_refs_in_all_of_should_expand_to_single_def()
+        {
+            var schema = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'id': 'http://some.domain.com/foo.json',
+                'type': 'object',
+                'additionalProperties': false,
+                'definitions': {
+                    'tRef1': {
+                        'type': 'object',
+                        'properties': {
+                            'val1': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef2': {
+                        'type': 'object',
+                        'properties': {
+                            'val2': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef3': {
+                        'type': 'object',
+                        'properties': {
+                            'val3': {
+                                'type': 'string',
+                            }
+                        }
+                    }
+                },
+                'tAgg': {
+                    'allOf': [
+                        {'$ref': '#/definitions/tRef1'},
+                        {'$ref': '#/definitions/tRef2'},
+                        {'$ref': '#/definitions/tRef3'}
+                    ]
+                }
+            }";
+            var s = NJsonSchema.JsonSchema4.FromJson(schema);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var gen = new CSharpGenerator(s, settings);
+            var output = gen.GenerateFile();
+            System.Console.WriteLine(output);
+        } 
 
         class CustomPropertyNameGenerator : IPropertyNameGenerator
         {

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -16,6 +16,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var schema = @"{
                 '$schema': 'http://json-schema.org/draft-04/schema#',
                 'id': 'http://some.domain.com/foo.json',
+                'x-typeName': 'foo',
                 'type': 'object',
                 'additionalProperties': false,
                 'definitions': {
@@ -44,12 +45,14 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
                         }
                     }
                 },
-                'tAgg': {
-                    'allOf': [
-                        {'$ref': '#/definitions/tRef1'},
-                        {'$ref': '#/definitions/tRef2'},
-                        {'$ref': '#/definitions/tRef3'}
-                    ]
+                'properties' : {
+                    'tAgg': {
+                        'allOf': [
+                            {'$ref': '#/definitions/tRef1'},
+                            {'$ref': '#/definitions/tRef2'},
+                            {'$ref': '#/definitions/tRef3'}
+                        ]
+                    }
                 }
             }";
             var s = NJsonSchema.JsonSchema4.FromJson(schema);
@@ -57,6 +60,13 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var gen = new CSharpGenerator(s, settings);
             var output = gen.GenerateFile();
             System.Console.WriteLine(output);
+
+            /// Assert
+            Assert.IsTrue(output.Contains("public partial class tAgg"));
+            Assert.IsTrue(output.Contains("public string Val1 { get; set; }"));
+            Assert.IsTrue(output.Contains("public string Val2 { get; set; }"));
+            Assert.IsTrue(output.Contains("public string Val3 { get; set; }"));
+
         } 
 
         class CustomPropertyNameGenerator : IPropertyNameGenerator

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
@@ -73,6 +73,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
         {
             var typeName = _schema.GetTypeName(Settings.TypeNameGenerator);
 
+            // if schema is a allOf schema, expand properties to 
+
+
             if (string.IsNullOrEmpty(typeName))
                 typeName = fallbackTypeName;
 
@@ -84,9 +87,18 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         private TypeGeneratorResult GenerateClass(string typeName)
         {
+
             var properties = _schema.Properties.Values
                 .Select(property => new PropertyModel(property, _resolver, Settings))
                 .ToList();
+
+            if (_schema.AllOf.Count > 1)
+            {
+                var allOfProperties = _schema.AllOf
+                    .SelectMany(s => s.ActualSchema.Properties.Values.Select(property => new PropertyModel(property, _resolver, Settings)))
+                   .ToList();
+                properties.AddRange(allOfProperties);
+            }
 
             var model = new ClassTemplateModel(typeName, Settings, _resolver, _schema, properties); 
 

--- a/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/CSharp/CSharpGenerator.cs
@@ -92,7 +92,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 .Select(property => new PropertyModel(property, _resolver, Settings))
                 .ToList();
 
-            if (_schema.AllOf.Count > 1)
+            if (_schema.AllOf.Count > 2)
             {
                 var allOfProperties = _schema.AllOf
                     .SelectMany(s => s.ActualSchema.Properties.Values.Select(property => new PropertyModel(property, _resolver, Settings)))


### PR DESCRIPTION
Here's a test for a potential issue - test crashes with a null ref exception for a schema that contains a field of type array, and has no items property.

Json schema specification docs indicate that schema is valid and should be interpreted as if items property was specified with an empty schema as it's value.

Validation keywords for arrays: http://json-schema.org/latest/json-schema-validation.html#anchor36