### PR TITLE
Test uncovering an issue with arrays with no items handling

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -3,13 +3,29 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.Tests.Models;
-using System;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {
     [TestClass]
     public class CSharpGeneratorTests
     {
+
+        [TestMethod]
+        [Ignore]
+        public void array_with_no_items_present_should_be_considered_to_have_items_with_empty_schema_content()
+        {
+            var schema = @"{
+                                'properties': {
+                                    'emptySchema': { 'type': 'array' }
+                                }
+                            }";
+            var s = NJsonSchema.JsonSchema4.FromJson(schema);
+            var settings = new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns", };
+            var gen = new CSharpGenerator(s, settings);
+            var output = gen.GenerateFile();
+
+            // assert once we know what kind of code is generated: List<dynamic>? 
+        }
 
         class CustomPropertyNameGenerator : IPropertyNameGenerator
         {


### PR DESCRIPTION
According to json schema specs schema with an array type, but no items, are
valid. They should be interpreted as if the items was present and contained an
empty schema value.

http://json-schema.org/latest/json-schema-validation.html#anchor36