### PR TITLE
Make explicit what are the additional properties causing the validation failure

### DIFF
--- a/src/NJsonSchema.Tests/Validation/PatternPropertyValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/PatternPropertyValidationTests.cs
@@ -25,8 +25,11 @@ namespace NJsonSchema.Tests.Validation
             var errors = schema.Validate(token);
 
             //// Assert
-            Assert.AreEqual(1, errors.Count());
-            Assert.AreEqual(ValidationErrorKind.NoAdditionalPropertiesAllowed, errors.First().Kind);
+            Assert.AreEqual(2, errors.Count());
+            foreach (var validationError in errors)
+            {
+                Assert.AreEqual(ValidationErrorKind.NoAdditionalPropertiesAllowed, validationError.Kind);
+            }
         }
 
         [TestMethod]

--- a/src/NJsonSchema.Tests/Validation/SchemaTests.cs
+++ b/src/NJsonSchema.Tests/Validation/SchemaTests.cs
@@ -328,7 +328,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.IsNotNull(error);
-            Assert.AreEqual("#", error.Path);
+            Assert.AreEqual("#/Key", error.Path);
         }
     }
 }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -369,7 +369,10 @@ namespace NJsonSchema.Validation
             else
             {
                 if (!_schema.AllowAdditionalProperties && additionalProperties.Any())
-                    errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, propertyName, propertyPath));
+                {
+                    foreach (var property in additionalProperties)
+                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, property.Path));
+                }
             }
         }
 


### PR DESCRIPTION
Currently, when no additional properties are allowed the validation error give you no clue about what properties are causing the failure. 

With this PR I propose to add an error per property, so that we can easily know where is the problem.  

For example, giving the following schema,

```json
{
 "type": "object",
 "properties": {
   "foo": {
      "type": "object",
      "additionalProperties": false
   }
 },
 "additionalProperties": false
}
```

when validating this JSON,

````json
{ "foo": { "bar": "mybar" } }
```

we will get the following ValidationError:

```csharp
{NoAdditionalPropertiesAllowed: #/foo.bar}
    Kind: NoAdditionalPropertiesAllowed
    Path: "#/foo.bar"
    Property: "bar"
```

We are really interested in having this information when running validations in our CI server. 

Looking forward your feedback.

Thanks,

Roger