### PR TITLE
Add ToString method to validation error objects

### DIFF
--- a/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
+++ b/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
@@ -25,6 +25,24 @@ namespace NJsonSchema.Validation
         }
         
         /// <summary>Gets the errors for each validated subschema. </summary>
-        public IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> Errors { get; private set; } 
+        public IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> Errors { get; private set; }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            var output = string.Format("{0} error in {1}:\n", Kind, Path);
+            foreach (var error in Errors)
+            {
+                output += "{\n";
+                foreach (var validationError in error.Value)
+                {
+                    output += string.Format("  {0}\n", validationError.ToString().Replace("\n", "\n  "));
+                }
+                output += "}\n";
+            }
+            return output;
+        }        
     }
 }

--- a/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
+++ b/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
@@ -32,7 +32,7 @@ namespace NJsonSchema.Validation
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            var output = string.Format("{0} error in {1}:\n", Kind, Path);
+            var output = string.Format("{0}: {1}\n", Kind, Path);
             foreach (var error in Errors)
             {
                 output += "{\n";

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -30,5 +30,13 @@ namespace NJsonSchema.Validation
 
         /// <summary>Gets the property path. </summary>
         public string Path { get; private set; }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return string.Format("{0}: {1}", Kind, Path);
+        }
     }
 }


### PR DESCRIPTION
In order to improve error reporting, in this PR I propose to add ToString methods for both ValidationError and ChildSchemaValidationError.

For instance, given the following schema:

```json
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "additionalProperties": false,
  "properties": {
    "data": {
      "oneOf": [
        {
          "$ref": "#/definitions/DataModel"
        },
        {
          "type": "null"
        }
      ]
    }
  },
  "definitions": {
    "DataModel": {
      "type": "object",
      "additionalProperties": false,
      "properties": {
        "foo": {
          "type": "integer"
        }        
      }
    }
  }
}
```
when validating this JSON,
```json
{ "data": { "bar": 4 } }
```
we would get this string error:
```
NotOneOf error in #/data:
{
  NoAdditionalPropertiesAllowed: #/data.bar
}
{
  NullExpected: #
}
```

Looking forward your feedback.

Roger