### PR TITLE
Fix absolute paths on validation errors

### DIFF
--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -627,7 +627,7 @@ namespace NJsonSchema
         public ICollection<ValidationError> Validate(JToken token)
         {
             var validator = new JsonSchemaValidator(ActualSchema);
-            return validator.Validate(token, null, null);
+            return validator.Validate(token, null, token.Path);
         }
 
         /// <summary>Finds the root parent of this schema. </summary>

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -296,7 +296,7 @@ namespace NJsonSchema.Validation
             var obj = token as JObject;
             foreach (var propertyInfo in _schema.Properties)
             {
-                var newPropertyPath = propertyName != null ? propertyName + "." + propertyInfo.Key : propertyInfo.Key;
+                var newPropertyPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + propertyInfo.Key : propertyInfo.Key;
 
                 var property = obj?.Property(propertyInfo.Key);
                 if (property != null)
@@ -371,7 +371,10 @@ namespace NJsonSchema.Validation
                 if (!_schema.AllowAdditionalProperties && additionalProperties.Any())
                 {
                     foreach (var property in additionalProperties)
-                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, property.Path));
+                    {
+                        var newPropertyPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + property.Name : property.Name;
+                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, newPropertyPath));
+                    }
                 }
             }
         }
@@ -396,7 +399,7 @@ namespace NJsonSchema.Validation
                     var item = array[index];
 
                     var propertyIndex = string.Format("[{0}]", index);
-                    var itemPath = propertyName != null ? propertyName + "." + propertyIndex : propertyIndex;
+                    var itemPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + propertyIndex : propertyIndex;
 
                     if (_schema.Item != null && itemValidator != null)
                     {
@@ -453,7 +456,7 @@ namespace NJsonSchema.Validation
 
         private ChildSchemaValidationError TryCreateChildSchemaError(JsonSchemaValidator validator, JsonSchema4 schema, JToken token, ValidationErrorKind errorKind, string property, string path)
         {
-            var errors = validator.Validate(token, null, null);
+            var errors = validator.Validate(token, null, path);
             if (errors.Count == 0)
                 return null;
 

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -399,7 +399,7 @@ namespace NJsonSchema.Validation
                     var item = array[index];
 
                     var propertyIndex = string.Format("[{0}]", index);
-                    var itemPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + propertyIndex : propertyIndex;
+                    var itemPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + propertyIndex : propertyIndex;
 
                     if (_schema.Item != null && itemValidator != null)
                     {


### PR DESCRIPTION
Currently some errors don't have a path that is absolute. With this PR we try to make all paths to be absolute. I.e.,

```
NotOneOf: #/data
{
  IntegerExpected: #/data.foo
  NoAdditionalPropertiesAllowed: #/data.bar
}
{
  NullExpected: #/data
}
```

or when a model contains a list

```
NotOneOf: #/data
{ 
  ArrayItemNotValid: #/participants.[0]
  {
    ObjectExpected: #/participants.[0]
    PropertyRequired: #/participants.[0].id
  }
  NullExpected: #/data.participants
}
{
  NullExpected: #/data
}
```

Looking forward your feedback.

Thanks,

Roger