### PR TITLE
Fix bug with ref that is file reference plus json path

### DIFF
--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NJsonSchema.Infrastructure;
 
 namespace NJsonSchema
@@ -127,7 +128,7 @@ namespace NJsonSchema
             {
                 try
                 {
-                    var arr = url.Split('#');
+                    var arr = Regex.Split(url, @"(?=#)");
 
                     if (!_resolvedSchemas.ContainsKey(arr[0]))
                         _resolvedSchemas[arr[0]] = JsonSchema4.FromFile(arr[0]);


### PR DESCRIPTION
This fixes a bug that causes an exception to be thrown when a `$ref` is a file reference plus a JSON path, e.g.
```JSON
{ "$ref": "path/to/file.json#/definitions/foo" }
```

Previously, the "#" was stripped out, so the JSON path part of the reference did not resolve. This change just leaves it in.

@rsuter I'm not sure of your process, but if let me know if you'd like me to create an issue for this bug and for #172 