### PR TITLE
Take into account the name of JsonPropertyAttribute when PropertyNameHandling is CamelCase

### DIFF
--- a/src/NJsonSchema.Tests/Generation/PropertyNamesGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PropertyNamesGenerationTests.cs
@@ -13,10 +13,10 @@ namespace NJsonSchema.Tests.Generation
         [DataContract]
         public class Foo
         {
-            [JsonProperty("BARbar1")]
+            [JsonProperty("BarBar1JsonProperty")]
             public string BarBar1 { get; set; }
 
-            [DataMember(Name = "BARbar2")]
+            [DataMember(Name = "BarBar2DataMember")]
             public string BarBar2 { get; set; }
         }
 
@@ -34,10 +34,10 @@ namespace NJsonSchema.Tests.Generation
             var data = schema.ToJson();
 
             //// Assert
-            Assert.IsTrue(schema.Properties.ContainsKey("BARbar1"));
-            Assert.AreEqual("BARbar1", schema.Properties["BARbar1"].Name);
-            Assert.IsTrue(schema.Properties.ContainsKey("BARbar2"));
-            Assert.AreEqual("BARbar2", schema.Properties["BARbar2"].Name);
+            Assert.IsTrue(schema.Properties.ContainsKey("BarBar1JsonProperty"));
+            Assert.AreEqual("BarBar1JsonProperty", schema.Properties["BarBar1JsonProperty"].Name);
+            Assert.IsTrue(schema.Properties.ContainsKey("BarBar2DataMember"));
+            Assert.AreEqual("BarBar2DataMember", schema.Properties["BarBar2DataMember"].Name);
         }
 
         [TestMethod]
@@ -54,10 +54,10 @@ namespace NJsonSchema.Tests.Generation
             var data = schema.ToJson();
 
             //// Assert
-            Assert.IsTrue(schema.Properties.ContainsKey("barBar1"));
-            Assert.AreEqual("barBar1", schema.Properties["barBar1"].Name);
-            Assert.IsTrue(schema.Properties.ContainsKey("barBar2"));
-            Assert.AreEqual("barBar2", schema.Properties["barBar2"].Name);
+            Assert.IsTrue(schema.Properties.ContainsKey("barBar1JsonProperty"));
+            Assert.AreEqual("barBar1JsonProperty", schema.Properties["barBar1JsonProperty"].Name);
+            Assert.IsTrue(schema.Properties.ContainsKey("barBar2DataMember"));
+            Assert.AreEqual("barBar2DataMember", schema.Properties["barBar2DataMember"].Name);
         }
     }
 }

--- a/src/NJsonSchema/JsonPathUtilities.cs
+++ b/src/NJsonSchema/JsonPathUtilities.cs
@@ -26,13 +26,14 @@ namespace NJsonSchema
         /// <exception cref="NotSupportedException">The PropertyNameHandling is not supported.</exception>
         public static string GetPropertyName(MemberInfo property, PropertyNameHandling propertyNameHandling)
         {
+            var propertyName = ReflectionCache.GetProperties(property.DeclaringType).First(p => p.MemberInfo.Name == property.Name).GetName();
             switch (propertyNameHandling)
             {
                 case PropertyNameHandling.Default:
-                    return ReflectionCache.GetProperties(property.DeclaringType).First(p => p.MemberInfo.Name == property.Name).GetName();
+                    return propertyName;
 
                 case PropertyNameHandling.CamelCase:
-                    return CamelCaseResolverLazy.Value.GetResolvedPropertyName(property.Name);
+                    return CamelCaseResolverLazy.Value.GetResolvedPropertyName(propertyName);
 
                 default:
                     throw new NotSupportedException($"The PropertyNameHandling '{propertyNameHandling}' is not supported.");


### PR DESCRIPTION
Currently, when PropertyNameHandling is CamelCase then the name of JsonPropertyAttribute is not used as json property name. In this PR we do the same than the Default case but applying camelcase after that.