### PR TITLE
Added line number information to errors

### DIFF
--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Generation\TypeMappingsTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
+    <Compile Include="Validation\LineInformationTest.cs" />
     <Compile Include="Validation\NullPropertyTests.cs" />
     <Compile Include="Validation\PatternPropertyValidationTests.cs" />
     <Compile Include="Validation\FormatBase64Tests.cs" />

--- a/src/NJsonSchema.Tests/Validation/LineInformationTest.cs
+++ b/src/NJsonSchema.Tests/Validation/LineInformationTest.cs
@@ -71,7 +71,7 @@ namespace NJsonSchema.Tests.Validation
         {
             foreach (var error in errors)
             {
-                Assert.AreEqual(hasLineInfo, error.HasLineInfo(), "HasLineInfo incorrect.");
+                Assert.AreEqual(hasLineInfo, error.HasLineInfo, "HasLineInfo incorrect.");
 
                 if (hasLineInfo)
                 {

--- a/src/NJsonSchema.Tests/Validation/LineInformationTest.cs
+++ b/src/NJsonSchema.Tests/Validation/LineInformationTest.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NJsonSchema.Validation;
+
+namespace NJsonSchema.Tests.Validation
+{
+    [TestClass]
+    public class LineInformationTest
+    {
+        private static JsonSchema4 Schema { get; set; }
+        private static string Json { get; set; }
+
+        [ClassInitialize]
+        public static void Init(TestContext context)
+        {
+            Schema = JsonSchema4.FromJson(@"{
+                ""type"": ""object"",
+                ""required"": [""prop1"", ""prop3""],
+                ""additionalProperties"": false,
+                ""properties"": {
+                    ""prop1"": {
+                        ""type"": ""string""
+                    },
+                    ""prop2"": {
+                        ""type"": ""number"",
+                        ""enum"": [""this"", ""that""]
+                    },
+                    ""prop3"": {}
+                }
+            }");
+
+            Json = @"{
+                ""prop1"": 12,
+                ""prop2"": ""something"",
+                ""prop4"": null
+            }";
+        }
+
+        [TestMethod]
+        public void When_validating_from_string_parse_line_information()
+        {
+            //// Act
+            var errors = Schema.Validate(Json);
+
+            //// Assert
+            Assert.AreEqual(5, errors.Count, "Five validation errors expected.");
+            ValidateErrors(errors, true);
+        }
+
+        [TestMethod]
+        public void When_validating_from_jtoken_parse_line_information_if_exists()
+        {
+            //// Act
+            var tokenWithInfo = JToken.Parse(Json, new JsonLoadSettings() {LineInfoHandling = LineInfoHandling.Ignore});
+            var errorsWithInfo = Schema.Validate(tokenWithInfo);
+            var tokenNoInfoParse = JToken.Parse(Json, new JsonLoadSettings() {LineInfoHandling = LineInfoHandling.Load});
+            var errorsNoInfoParse = Schema.Validate(tokenNoInfoParse);
+            var tokenNoInfoDeserialize = JsonConvert.DeserializeObject<JToken>(Json);
+            var errorsNoInfoDeserialize = Schema.Validate(tokenNoInfoDeserialize);
+
+            //// Assert
+            ValidateErrors(errorsWithInfo, true);
+            ValidateErrors(errorsNoInfoParse, false);
+            ValidateErrors(errorsNoInfoDeserialize, false);
+        }
+
+        private static void ValidateErrors(IEnumerable<ValidationError> errors, bool hasLineInfo)
+        {
+            foreach (var error in errors)
+            {
+                Assert.AreEqual(hasLineInfo, error.HasLineInfo(), "HasLineInfo incorrect.");
+
+                if (hasLineInfo)
+                {
+                    switch (error.Kind)
+                    {
+                    case ValidationErrorKind.StringExpected:
+                        Assert.AreEqual(2, error.LineNumber, string.Format("Line number unexpected for {0} error.", error.Kind));
+                        Assert.AreEqual(27, error.LinePosition, string.Format("Line position unexpected for {0} error.", error.Kind));
+                        break;
+                    case ValidationErrorKind.NumberExpected:
+                        Assert.AreEqual(3, error.LineNumber, string.Format("Line number unexpected for {0} error.", error.Kind));
+                        Assert.AreEqual(36, error.LinePosition, string.Format("Line position unexpected for {0} error.", error.Kind));
+                        break;
+                    case ValidationErrorKind.NotInEnumeration:
+                        Assert.AreEqual(3, error.LineNumber, string.Format("Line number unexpected for {0} error.", error.Kind));
+                        Assert.AreEqual(36, error.LinePosition, string.Format("Line position unexpected for {0} error.", error.Kind));
+                        break;
+                    case ValidationErrorKind.PropertyRequired:
+                        Assert.AreEqual(1, error.LineNumber, string.Format("Line number unexpected for {0} error.", error.Kind));
+                        Assert.AreEqual(1, error.LinePosition, string.Format("Line position unexpected for {0} error.", error.Kind));
+                        break;
+                    case ValidationErrorKind.NoAdditionalPropertiesAllowed:
+                        Assert.AreEqual(1, error.LineNumber, string.Format("Line number unexpected for {0} error.", error.Kind));
+                        Assert.AreEqual(1, error.LinePosition, string.Format("Line position unexpected for {0} error.", error.Kind));
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(error.Kind));
+                    }
+                }
+                else
+                {
+                    Assert.AreEqual(0, error.LineNumber, "Line number not zero with no error info.");
+                    Assert.AreEqual(0, error.LinePosition, "Line position not zero with no error info.");
+                }
+            }
+        }
+    }
+}

--- a/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
+++ b/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace NJsonSchema.Validation
 {
@@ -18,12 +19,13 @@ namespace NJsonSchema.Validation
         /// <param name="property">The property name. </param>
         /// <param name="path">The property path. </param>
         /// <param name="errors">The error list. </param>
+        /// <param name="token">The token that failed to validate. </param>
 #if !LEGACY
-        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> errors)
+        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token)
 #else
-        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IDictionary<JsonSchema4, ICollection<ValidationError>> errors)
+        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token)
 #endif
-            : base(kind, property, path)
+            : base(kind, property, path, token)
         {
             Errors = errors;
         }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace NJsonSchema.Validation
@@ -24,8 +23,7 @@ namespace NJsonSchema.Validation
         /// <returns>The list of validation errors.</returns>
         public ICollection<ValidationError> Validate(string jsonData, JsonSchema4 schema)
         {
-            var settings = new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Ignore };
-            var jsonObject = JToken.Parse(jsonData, settings);
+            var jsonObject = JToken.Parse(jsonData);
             return Validate(jsonObject, schema);
         }
 

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -24,8 +24,8 @@ namespace NJsonSchema.Validation
         /// <returns>The list of validation errors.</returns>
         public ICollection<ValidationError> Validate(string jsonData, JsonSchema4 schema)
         {
-            var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
-            var jsonObject = JsonConvert.DeserializeObject<JToken>(jsonData, settings);
+            var settings = new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Ignore };
+            var jsonObject = JToken.Parse(jsonData, settings);
             return Validate(jsonObject, schema);
         }
 
@@ -108,7 +108,7 @@ namespace NJsonSchema.Validation
             {
                 var propertyErrors = schema.AnyOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.All(s => s.Value.Count != 0))
-                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAnyOf, propertyName, propertyPath, propertyErrors));
+                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAnyOf, propertyName, propertyPath, propertyErrors, token));
             }
         }
 
@@ -118,7 +118,7 @@ namespace NJsonSchema.Validation
             {
                 var propertyErrors = schema.AllOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.Any(s => s.Value.Count != 0))
-                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAllOf, propertyName, propertyPath, propertyErrors));
+                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAllOf, propertyName, propertyPath, propertyErrors, token));
             }
         }
 
@@ -128,7 +128,7 @@ namespace NJsonSchema.Validation
             {
                 var propertyErrors = schema.OneOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.Count(s => s.Value.Count == 0) != 1)
-                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotOneOf, propertyName, propertyPath, propertyErrors));
+                    errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotOneOf, propertyName, propertyPath, propertyErrors, token));
             }
         }
 
@@ -137,7 +137,7 @@ namespace NJsonSchema.Validation
             if (schema.Not != null)
             {
                 if (Validate(token, schema.Not).Count == 0)
-                    errors.Add(new ValidationError(ValidationErrorKind.ExcludedSchemaValidates, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.ExcludedSchemaValidates, propertyName, propertyPath, token));
             }
         }
 
@@ -146,14 +146,14 @@ namespace NJsonSchema.Validation
             if (type.HasFlag(JsonObjectType.Null))
             {
                 if (token != null && token.Type != JTokenType.Null)
-                    errors.Add(new ValidationError(ValidationErrorKind.NullExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.NullExpected, propertyName, propertyPath, token));
             }
         }
 
         private void ValidateEnum(JToken token, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.Enumeration.Count > 0 && schema.Enumeration.All(v => v.ToString() != token.ToString()))
-                errors.Add(new ValidationError(ValidationErrorKind.NotInEnumeration, propertyName, propertyPath));
+                errors.Add(new ValidationError(ValidationErrorKind.NotInEnumeration, propertyName, propertyPath, token));
         }
 
         private void ValidateString(JToken token, JsonSchema4 schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
@@ -170,14 +170,14 @@ namespace NJsonSchema.Validation
                     if (!string.IsNullOrEmpty(schema.Pattern))
                     {
                         if (!Regex.IsMatch(value, schema.Pattern))
-                            errors.Add(new ValidationError(ValidationErrorKind.PatternMismatch, propertyName, propertyPath));
+                            errors.Add(new ValidationError(ValidationErrorKind.PatternMismatch, propertyName, propertyPath, token));
                     }
 
                     if (schema.MinLength.HasValue && value.Length < schema.MinLength)
-                        errors.Add(new ValidationError(ValidationErrorKind.StringTooShort, propertyName, propertyPath));
+                        errors.Add(new ValidationError(ValidationErrorKind.StringTooShort, propertyName, propertyPath, token));
 
                     if (schema.MaxLength.HasValue && value.Length > schema.MaxLength)
-                        errors.Add(new ValidationError(ValidationErrorKind.StringTooLong, propertyName, propertyPath));
+                        errors.Add(new ValidationError(ValidationErrorKind.StringTooLong, propertyName, propertyPath, token));
 
                     if (!string.IsNullOrEmpty(schema.Format))
                     {
@@ -185,14 +185,14 @@ namespace NJsonSchema.Validation
                         {
                             DateTime dateTimeResult;
                             if (token.Type != JTokenType.Date && DateTime.TryParse(value, out dateTimeResult) == false)
-                                errors.Add(new ValidationError(ValidationErrorKind.DateTimeExpected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.DateTimeExpected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.Uri)
                         {
                             Uri uriResult;
                             if (token.Type != JTokenType.Uri && Uri.TryCreate(value, UriKind.Absolute, out uriResult) == false)
-                                errors.Add(new ValidationError(ValidationErrorKind.UriExpected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.UriExpected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.Email)
@@ -201,7 +201,7 @@ namespace NJsonSchema.Validation
                                 @"^\A(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*" +
                                 @"@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\Z$", RegexOptions.IgnoreCase);
                             if (!isEmail)
-                                errors.Add(new ValidationError(ValidationErrorKind.EmailExpected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.EmailExpected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.IpV4)
@@ -210,7 +210,7 @@ namespace NJsonSchema.Validation
                                 @"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", RegexOptions.IgnoreCase);
 
                             if (!isIpV4)
-                                errors.Add(new ValidationError(ValidationErrorKind.IpV4Expected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.IpV4Expected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.IpV6)
@@ -218,14 +218,14 @@ namespace NJsonSchema.Validation
                             var isIpV6 = Uri.CheckHostName(value) == UriHostNameType.IPv6;
 
                             if (!isIpV6)
-                                errors.Add(new ValidationError(ValidationErrorKind.IpV6Expected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.IpV6Expected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.Guid)
                         {
                             Guid guid;
                             if (Guid.TryParse(value, out guid) == false)
-                                errors.Add(new ValidationError(ValidationErrorKind.GuidExpected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.GuidExpected, propertyName, propertyPath, token));
                         }
 
                         if (schema.Format == JsonFormatStrings.Hostname)
@@ -233,7 +233,7 @@ namespace NJsonSchema.Validation
                             var isHostname = Regex.IsMatch(value, "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*" +
                                                                   "([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$", RegexOptions.IgnoreCase);
                             if (!isHostname)
-                                errors.Add(new ValidationError(ValidationErrorKind.HostnameExpected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.HostnameExpected, propertyName, propertyPath, token));
                         }
 
 #pragma warning disable 618 //Base64 check is used for backward compatibility
@@ -243,7 +243,7 @@ namespace NJsonSchema.Validation
                             var isBase64 = (value.Length % 4 == 0) && Regex.IsMatch(value, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
 
                             if (!isBase64)
-                                errors.Add(new ValidationError(ValidationErrorKind.Base64Expected, propertyName, propertyPath));
+                                errors.Add(new ValidationError(ValidationErrorKind.Base64Expected, propertyName, propertyPath, token));
                         }
                     }
                 }
@@ -251,7 +251,7 @@ namespace NJsonSchema.Validation
             else
             {
                 if (type.HasFlag(JsonObjectType.String))
-                    errors.Add(new ValidationError(ValidationErrorKind.StringExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.StringExpected, propertyName, propertyPath, token));
             }
         }
 
@@ -260,7 +260,7 @@ namespace NJsonSchema.Validation
             if (type.HasFlag(JsonObjectType.Number))
             {
                 if (token.Type != JTokenType.Float && token.Type != JTokenType.Integer)
-                    errors.Add(new ValidationError(ValidationErrorKind.NumberExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.NumberExpected, propertyName, propertyPath, token));
             }
 
             if (token.Type == JTokenType.Float || token.Type == JTokenType.Integer)
@@ -268,13 +268,13 @@ namespace NJsonSchema.Validation
                 var value = token.Value<decimal>();
 
                 if (schema.Minimum.HasValue && (schema.IsExclusiveMinimum ? value <= schema.Minimum : value < schema.Minimum))
-                    errors.Add(new ValidationError(ValidationErrorKind.NumberTooSmall, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.NumberTooSmall, propertyName, propertyPath, token));
 
                 if (schema.Maximum.HasValue && (schema.IsExclusiveMaximum ? value >= schema.Maximum : value > schema.Maximum))
-                    errors.Add(new ValidationError(ValidationErrorKind.NumberTooBig, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.NumberTooBig, propertyName, propertyPath, token));
 
                 if (schema.MultipleOf.HasValue && value % schema.MultipleOf != 0)
-                    errors.Add(new ValidationError(ValidationErrorKind.NumberNotMultipleOf, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.NumberNotMultipleOf, propertyName, propertyPath, token));
             }
         }
 
@@ -283,7 +283,7 @@ namespace NJsonSchema.Validation
             if (type.HasFlag(JsonObjectType.Integer))
             {
                 if (token.Type != JTokenType.Integer)
-                    errors.Add(new ValidationError(ValidationErrorKind.IntegerExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.IntegerExpected, propertyName, propertyPath, token));
             }
         }
 
@@ -292,7 +292,7 @@ namespace NJsonSchema.Validation
             if (type.HasFlag(JsonObjectType.Boolean))
             {
                 if (token.Type != JTokenType.Boolean)
-                    errors.Add(new ValidationError(ValidationErrorKind.BooleanExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.BooleanExpected, propertyName, propertyPath, token));
             }
         }
 
@@ -302,7 +302,7 @@ namespace NJsonSchema.Validation
             {
                 var obj = token as JObject;
                 if (obj == null)
-                    errors.Add(new ValidationError(ValidationErrorKind.ObjectExpected, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.ObjectExpected, propertyName, propertyPath, token));
             }
         }
 
@@ -323,33 +323,33 @@ namespace NJsonSchema.Validation
                     errors.AddRange(propertyErrors);
                 }
                 else if (propertyInfo.Value.IsRequired)
-                    errors.Add(new ValidationError(ValidationErrorKind.PropertyRequired, propertyInfo.Key, newPropertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.PropertyRequired, propertyInfo.Key, newPropertyPath, token));
             }
 
             if (obj != null)
             {
                 var properties = obj.Properties().ToList();
 
-                ValidateMaxProperties(properties, schema, propertyName, propertyPath, errors);
-                ValidateMinProperties(properties, schema, propertyName, propertyPath, errors);
+                ValidateMaxProperties(token, properties, schema, propertyName, propertyPath, errors);
+                ValidateMinProperties(token, properties, schema, propertyName, propertyPath, errors);
 
                 var additionalProperties = properties.Where(p => !schema.Properties.ContainsKey(p.Name)).ToList();
 
                 ValidatePatternProperties(additionalProperties, schema, errors);
-                ValidateAdditionalProperties(additionalProperties, schema, propertyName, propertyPath, errors);
+                ValidateAdditionalProperties(token, additionalProperties, schema, propertyName, propertyPath, errors);
             }
         }
 
-        private void ValidateMaxProperties(IList<JProperty> properties, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
+        private void ValidateMaxProperties(JToken token, IList<JProperty> properties, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.MaxProperties > 0 && properties.Count() > schema.MaxProperties)
-                errors.Add(new ValidationError(ValidationErrorKind.TooManyProperties, propertyName, propertyPath));
+                errors.Add(new ValidationError(ValidationErrorKind.TooManyProperties, propertyName, propertyPath, token));
         }
 
-        private void ValidateMinProperties(IList<JProperty> properties, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
+        private void ValidateMinProperties(JToken token, IList<JProperty> properties, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.MinProperties > 0 && properties.Count() < schema.MinProperties)
-                errors.Add(new ValidationError(ValidationErrorKind.TooFewProperties, propertyName, propertyPath));
+                errors.Add(new ValidationError(ValidationErrorKind.TooFewProperties, propertyName, propertyPath, token));
         }
 
         private void ValidatePatternProperties(List<JProperty> additionalProperties, JsonSchema4 schema, List<ValidationError> errors)
@@ -370,7 +370,7 @@ namespace NJsonSchema.Validation
             }
         }
 
-        private void ValidateAdditionalProperties(List<JProperty> additionalProperties, JsonSchema4 schema, 
+        private void ValidateAdditionalProperties(JToken token, List<JProperty> additionalProperties, JsonSchema4 schema, 
             string propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.AdditionalPropertiesSchema != null)
@@ -390,7 +390,7 @@ namespace NJsonSchema.Validation
                     foreach (var property in additionalProperties)
                     {
                         var newPropertyPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + property.Name : property.Name;
-                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, newPropertyPath));
+                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, newPropertyPath, token));
                     }
                 }
             }
@@ -402,13 +402,13 @@ namespace NJsonSchema.Validation
             if (array != null)
             {
                 if (schema.MinItems > 0 && array.Count < schema.MinItems)
-                    errors.Add(new ValidationError(ValidationErrorKind.TooFewItems, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.TooFewItems, propertyName, propertyPath, token));
 
                 if (schema.MaxItems > 0 && array.Count > schema.MaxItems)
-                    errors.Add(new ValidationError(ValidationErrorKind.TooManyItems, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.TooManyItems, propertyName, propertyPath, token));
 
                 if (schema.UniqueItems && array.Count != array.Select(a => a.ToString()).Distinct().Count())
-                    errors.Add(new ValidationError(ValidationErrorKind.ItemsNotUnique, propertyName, propertyPath));
+                    errors.Add(new ValidationError(ValidationErrorKind.ItemsNotUnique, propertyName, propertyPath, token));
 
                 for (var index = 0; index < array.Count; index++)
                 {
@@ -428,7 +428,7 @@ namespace NJsonSchema.Validation
                 }
             }
             else if (type.HasFlag(JsonObjectType.Array))
-                errors.Add(new ValidationError(ValidationErrorKind.ArrayExpected, propertyName, propertyPath));
+                errors.Add(new ValidationError(ValidationErrorKind.ArrayExpected, propertyName, propertyPath, token));
         }
 
         private void ValidateAdditionalItems(JToken item, JsonSchema4 schema, int index, string propertyPath, List<ValidationError> errors)
@@ -457,7 +457,7 @@ namespace NJsonSchema.Validation
                         if (!schema.AllowAdditionalItems)
                         {
                             errors.Add(new ValidationError(ValidationErrorKind.TooManyItemsInTuple,
-                                propertyIndex, propertyPath + propertyIndex));
+                                propertyIndex, propertyPath + propertyIndex, item));
                         }
                     }
                 }
@@ -473,7 +473,7 @@ namespace NJsonSchema.Validation
             var errorDictionary = new Dictionary<JsonSchema4, ICollection<ValidationError>>();
             errorDictionary.Add(schema, errors);
 
-            return new ChildSchemaValidationError(errorKind, property, path, errorDictionary);
+            return new ChildSchemaValidationError(errorKind, property, path, errorDictionary, token);
         }
     }
 }

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -6,6 +6,9 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace NJsonSchema.Validation
 {
     /// <summary>A validation error. </summary>
@@ -15,11 +18,24 @@ namespace NJsonSchema.Validation
         /// <param name="errorKind">The error kind. </param>
         /// <param name="propertyName">The property name. </param>
         /// <param name="propertyPath">The property path. </param>
-        public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath)
+        /// <param name="token">The token that failed to validate. </param>
+        public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath, JToken token)
         {
             Kind = errorKind;
             Property = propertyName;
             Path = propertyPath != null ? "#/" + propertyPath : "#";
+
+            var lineInfo = token as IJsonLineInfo;
+            if (lineInfo != null && lineInfo.HasLineInfo())
+            {
+                LineNumber = lineInfo.LineNumber;
+                LinePosition = lineInfo.LinePosition;
+            }
+            else
+            {
+                LineNumber = 0;
+                LinePosition = 0;
+            }
         }
 
         /// <summary>Gets the error kind. </summary>
@@ -30,6 +46,12 @@ namespace NJsonSchema.Validation
 
         /// <summary>Gets the property path. </summary>
         public string Path { get; private set; }
+
+        /// <summary> Gets the line number the validation failed on. </summary>
+        public int LineNumber { get; private set; }
+
+        /// <summary> Gets the line number the validation failed on. </summary>
+        public int LinePosition { get; private set; }
 
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -26,7 +26,8 @@ namespace NJsonSchema.Validation
             Path = propertyPath != null ? "#/" + propertyPath : "#";
 
             var lineInfo = token as IJsonLineInfo;
-            if (lineInfo != null && lineInfo.HasLineInfo())
+            _hasLineInfo = lineInfo != null && lineInfo.HasLineInfo();
+            if (HasLineInfo())
             {
                 LineNumber = lineInfo.LineNumber;
                 LinePosition = lineInfo.LinePosition;
@@ -47,10 +48,18 @@ namespace NJsonSchema.Validation
         /// <summary>Gets the property path. </summary>
         public string Path { get; private set; }
 
-        /// <summary> Gets the line number the validation failed on. </summary>
+        private readonly bool _hasLineInfo;
+
+        /// <summary>Indicates whether or not the error contains line information.</summary>
+        public bool HasLineInfo()
+        {
+            return _hasLineInfo;
+        }
+
+        /// <summary>Gets the line number the validation failed on. </summary>
         public int LineNumber { get; private set; }
 
-        /// <summary> Gets the line number the validation failed on. </summary>
+        /// <summary>Gets the line number the validation failed on. </summary>
         public int LinePosition { get; private set; }
 
         /// <summary>Returns a string that represents the current object.</summary>

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -59,7 +59,7 @@ namespace NJsonSchema.Validation
         /// <summary>Gets the line number the validation failed on. </summary>
         public int LineNumber { get; private set; }
 
-        /// <summary>Gets the line number the validation failed on. </summary>
+        /// <summary>Gets the line position the validation failed on. </summary>
         public int LinePosition { get; private set; }
 
         /// <summary>Returns a string that represents the current object.</summary>

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -26,8 +26,8 @@ namespace NJsonSchema.Validation
             Path = propertyPath != null ? "#/" + propertyPath : "#";
 
             var lineInfo = token as IJsonLineInfo;
-            _hasLineInfo = lineInfo != null && lineInfo.HasLineInfo();
-            if (HasLineInfo())
+            HasLineInfo = lineInfo != null && lineInfo.HasLineInfo();
+            if (HasLineInfo)
             {
                 LineNumber = lineInfo.LineNumber;
                 LinePosition = lineInfo.LinePosition;
@@ -48,13 +48,8 @@ namespace NJsonSchema.Validation
         /// <summary>Gets the property path. </summary>
         public string Path { get; private set; }
 
-        private readonly bool _hasLineInfo;
-
         /// <summary>Indicates whether or not the error contains line information.</summary>
-        public bool HasLineInfo()
-        {
-            return _hasLineInfo;
-        }
+        public bool HasLineInfo { get; private set; }
 
         /// <summary>Gets the line number the validation failed on. </summary>
         public int LineNumber { get; private set; }


### PR DESCRIPTION
This PR adds support for line number/position in validation errors. This can, for example, be integrated in Visual Studio to give clickable errors in the output which then go right to the JSON file line and position, just like with C# errors.

To do this I had to change how the JToken is initialized. I no longer use `JsonConvert.Deserialize<JToken>`, but instead `JToken.Parse`. This required removing the `DateParseHandling = DateParseHandling.None`, since `JToken.Parse` uses `JsonLoadSettings` instead of `JsonSerializerSettings`. However, the default behavior of `JToken.Parse` uses the same date parsing handler, i.e. it just reads in the strings instead of doing any conversions.

If people do not want to parse line information (although the extra cost is negligible when compared to the validation logic) they have that option by calling `Validate` on a `JToken` they parsed themselves with their own settings.

As for the design, I added a `HasLineInfo` method to mirror `IJsonLineInfo`. The default values are `0`, again as with `IJsonLineInfo`, to make usage familiar to people who have worked with that part of Json.NET before.

I also added unit tests that cover all added features, although not in all possible combinations, only with common JSON validation errors, since the specific kind of error should not make a difference in how the data is parsed.