### PR TITLE
Line Info: Adjusted to use the property as line marker

### DIFF
--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -388,7 +388,7 @@ namespace NJsonSchema.Validation
                     foreach (var property in additionalProperties)
                     {
                         var newPropertyPath = !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + property.Name : property.Name;
-                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, newPropertyPath, token));
+                        errors.Add(new ValidationError(ValidationErrorKind.NoAdditionalPropertiesAllowed, property.Name, newPropertyPath, property));
                     }
                 }
             }


### PR DESCRIPTION
This PR is meant to address the issue reported [here](https://github.com/NJsonSchema/NJsonSchema/pull/268#issuecomment-268639158).

Adjusted line info parsing to report the property's line info instead of the objects for `NoAdditionalPropertiesAllowed`.

Example - Schema:
```json
{
  "additionalProperties": false,
  "properties": {
    "foo": {}
  }
}
```

Example - JSON document:
```json
{
  "foo": 1,
  "bar": 2
}
```

Applying the above schema to this document would report an error with `ValidationErrorKind.NoAdditionalPropertiesAllowed`, as expected. However, the error would report line `1` at position `1`, because that's where the outer object starts.

This PR adjusts it so it reports the location of the property in violation (`bar` in this case), instead of the parent object.

The code change itself was simple, most of the PR adjusts the unit tests for line info objects to be a bit more complex and contain nested error structures (`oneOf` and `allOf`), to give a better overview of how it works. I verified that all unit tests still pass.