### PR TITLE
Introduce support for xmlObject

### DIFF
--- a/src/NJsonSchema.Tests/Generation/XmlObjectTests.cs
+++ b/src/NJsonSchema.Tests/Generation/XmlObjectTests.cs
@@ -1,0 +1,250 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema.Infrastructure;
+using Newtonsoft.Json.Linq;
+using System.Xml.Serialization;
+
+namespace NJsonSchema.Tests.Generation
+{
+    [TestClass]
+    public class XmlObjectTests
+    {
+        private const string StringArray = "StringArray";
+        private const string IntArray = "IntArray";
+        private const string DoubleArray = "DoubleArray";
+        private const string DecimalArray = "DecimalArray";
+        private const string InternalItemArray = "InternalItem";
+        private const string Foo = "Foo";
+
+        public class WithoutXmlAttributesDefined
+        {
+            public string Foo { get; set; }
+            public string[] StringArray { get; set; }
+            public int[] IntArray { get; set; }
+            public double[] DoubleArray { get; set; }
+            public decimal[] DecimalArray { get; set; }
+            public WithoutXmlAttributeItem[] InternalItem { get; set; }
+
+            public class WithoutXmlAttributeItem
+            {
+                public string Name { get; set; }
+            }
+
+            /*
+             * Class above is the XML outputted as presented below by the XMLSerializer 
+             *<?xml version="1.0" encoding="utf-16"?>
+             *<WithoutXmlAttributesDefined xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+             * <Foo>stringvalue</Foo>
+             * <StringArray>
+             *   <string>S1</string>
+             * </StringArray>
+             * <IntArray>
+             *   <int>1</int>
+             * </IntArray>
+             * <DoubleArray>
+             *  <double>1</double>
+             * </DoubleArray>
+             * <DecimalArray>
+             *  <decimal>1</decimal>
+             * </DecimalArray>
+             * <InternalItem>
+             *  <WithoutXmlAttributeItem>
+             *   <Name>Test</Name>
+             *  </WithoutXmlAttributeItem>
+             * </InternalItem>
+             *</WithoutXmlAttributesDefined>
+            */
+        }
+
+        [TestMethod]
+        public async Task When_xmlobject_generation_is_active_with_a_type_without_xml_attributes()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<WithoutXmlAttributesDefined>(new NJsonSchema.Generation.JsonSchemaGeneratorSettings() { GenerateXmlObject = true });
+            var schemaData = schema.ToJson();
+            XmlSerializerTestCode();
+            //// Assert
+            Assert.IsNull(schema.Xml);
+            var fooProperty = schema.Properties[Foo];
+            var stringArrayProperty = schema.Properties[StringArray];
+            var intArrayProperty = schema.Properties[IntArray];
+            var doubleArrayProperty = schema.Properties[DoubleArray];
+            var decimalArrayProperty = schema.Properties[DecimalArray];
+            var internalItemProperty = schema.Properties[InternalItemArray];
+
+            Assert.IsNull(internalItemProperty.Xml.Name);
+            Assert.IsNull(stringArrayProperty.Xml.Name);
+            Assert.IsNull(intArrayProperty.Xml.Name);
+            Assert.IsNull(doubleArrayProperty.Xml.Name);
+            Assert.IsNull(decimalArrayProperty.Xml.Name);
+            Assert.IsNull(fooProperty.Xml);
+
+            //https://github.com/swagger-api/swagger-ui/issues/2601
+            Assert.AreEqual(true, stringArrayProperty.Xml.Wrapped);
+            Assert.AreEqual(true, intArrayProperty.Xml.Wrapped);
+            Assert.AreEqual(true, doubleArrayProperty.Xml.Wrapped);
+            Assert.AreEqual(true, decimalArrayProperty.Xml.Wrapped);
+            Assert.AreEqual(true, internalItemProperty.Xml.Wrapped);
+
+            Assert.AreEqual(typeof(string).Name, stringArrayProperty.Item.Xml.Name);
+            Assert.AreEqual(typeof(int).Name, intArrayProperty.Item.Xml.Name);
+            Assert.AreEqual(typeof(double).Name, doubleArrayProperty.Item.Xml.Name);
+            Assert.AreEqual(typeof(decimal).Name, decimalArrayProperty.Item.Xml.Name);
+            Assert.IsNull(internalItemProperty.Item.Xml);
+        }
+
+        [TestMethod]
+        public async Task When_xmlobject_generation_is_active_with_a_type_without_xml_attributes_and_serialized()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<WithoutXmlAttributesDefined>(new NJsonSchema.Generation.JsonSchemaGeneratorSettings() { GenerateXmlObject = true });
+            var schemaData = schema.ToJson();
+
+            var schemaObject = JObject.Parse(schemaData);
+
+            var definitionXML = schemaObject["xml"];
+            Assert.IsNull(definitionXML);
+
+            var fooPropertyXml = schemaObject["properties"]["Foo"]["xml"];
+            Assert.IsNull(fooPropertyXml);
+
+            var arrayStringPropertyOuterXml = schemaObject["properties"][StringArray]["xml"];
+            Assert.AreEqual(true, arrayStringPropertyOuterXml["wrapped"].Value<bool>());
+            Assert.IsNull(arrayStringPropertyOuterXml["name"]);
+
+            var arrayStringPropertyItemXml = schemaObject["properties"][StringArray]["items"]["xml"];
+            Assert.AreEqual(typeof(string).Name, arrayStringPropertyItemXml["name"]);
+        }
+
+        [XmlType(TypeName ="NotTheSameName", Namespace = "http://test.shema.org/type")]
+        public class WithXmlAttributesDefined
+        {
+            [XmlElement(ElementName = "Bar", Namespace = "http://test.shema.org/type")]
+            public string Foo { get; set; }
+
+            [XmlAttribute("IsAnAttribute")]
+            public string MightBeAAttribute { get; set; }
+
+            [XmlArray(ElementName ="TheStrings", Namespace = "http://test.shema.org/type")]
+            [XmlArrayItem(ElementName = "TheString", Namespace = "http://test.shema.org/type")]
+            public string[] StringArray { get; set; }
+
+            [XmlArrayItem(ElementName = "TheInt", Namespace = "http://test.shema.org/type")]
+            public int[] TheInts { get; set; }
+
+            [XmlArray("ExternalItems")]
+            public WithXmlAttributeItem[] InternalItem { get; set; }
+
+            [XmlType("ExternalItem")]
+            public class WithXmlAttributeItem
+            {
+                public string Name { get; set; }
+            }
+
+            /*
+             * Class above is the XML outputted as presented below by the XMLSerializer 
+             *<?xml version="1.0" encoding="utf-16"?>
+             *<NotTheSameName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" IsAnAttribute="stringValue2">
+             * <Bar xmlns="http://test.shema.org/type">stringvalue</Bar>
+             * <TheStrings xmlns="http://test.shema.org/type">
+             *  <TheString>S1</TheString>
+             * </TheStrings>
+             * <TheInts xmlns="http://test.shema.org/type">
+             *  <TheInt>1</TheInt>
+             * </TheInts>
+             * <ExternalItems xmlns="http://test.shema.org/type">
+             *  <ExternalItem>
+             *    <Name>Test</Name>
+             *  </ExternalItem>
+             * </ExternalItems>
+             *</NotTheSameName>
+             * 
+             */
+        }
+
+        [TestMethod]
+        public async Task When_xmlobject_generation_is_active_with_a_type_with_xml_attributes()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<WithXmlAttributesDefined>(new NJsonSchema.Generation.JsonSchemaGeneratorSettings() { GenerateXmlObject = true });
+            var schemaData = schema.ToJson();
+            
+            //// Assert
+            Assert.AreEqual("NotTheSameName", schema.Xml.Name);
+            Assert.AreEqual("http://test.shema.org/type", schema.Xml.Namespace);
+
+            var stringArrayProperty = schema.Properties[StringArray];
+            var intArrayProperty = schema.Properties["TheInts"];
+            var fooProperty = schema.Properties["Foo"];
+            var attributeProperty = schema.Properties["MightBeAAttribute"];
+
+            Assert.AreEqual("Bar", fooProperty.Xml.Name);
+
+            Assert.AreEqual("TheStrings", stringArrayProperty.Xml.Name);
+            Assert.IsNull(intArrayProperty.Xml.Name);
+            //https://github.com/swagger-api/swagger-ui/issues/2601
+            Assert.AreEqual(true, stringArrayProperty.Xml.Wrapped);
+
+            Assert.AreEqual("TheString", stringArrayProperty.Item.Xml.Name);
+
+            Assert.AreEqual(true, attributeProperty.Xml.Attribute);
+        }
+
+        [TestMethod]
+        public async Task When_xmlobject_generation_is_active_with_a_type_with_xml_attributes_and_serialized()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<WithXmlAttributesDefined>(new NJsonSchema.Generation.JsonSchemaGeneratorSettings() { GenerateXmlObject = true });
+            var schemaData = schema.ToJson();
+
+            var schemaObject = JObject.Parse(schemaData);
+
+            var definitionXML = schemaObject["xml"];
+            Assert.AreEqual("NotTheSameName", definitionXML["name"]);
+
+            var fooPropertyXml = schemaObject["properties"]["Foo"]["xml"];
+            Assert.AreEqual("Bar", fooPropertyXml["name"]);
+
+            var arrayStringPropertyOuterXml = schemaObject["properties"][StringArray]["xml"];
+            Assert.AreEqual("TheStrings", arrayStringPropertyOuterXml["name"]);
+
+            var arrayStringPropertyItemXml = schemaObject["properties"][StringArray]["items"]["xml"];
+            Assert.AreEqual("TheString", arrayStringPropertyItemXml["name"]);
+        }
+
+        public class WithXmlIncorrectAttributesDefined
+        {
+            [XmlArray(ElementName = "TheStrings", Namespace = "http://test.shema.org/type")]
+            [XmlArrayItem(ElementName = "TheString", Namespace = "http://test.shema.org/type")]
+            public string Foo { get; set; }
+        }
+
+        [TestMethod]
+        public async Task When_xmlobject_generation_is_active_with_a_type_with_xml_attributes_that_are_incorrect()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<WithXmlIncorrectAttributesDefined>(new NJsonSchema.Generation.JsonSchemaGeneratorSettings() { GenerateXmlObject = true });
+            var schemaData = schema.ToJson();
+
+            //// Assert
+           var fooProperty = schema.Properties["Foo"];
+
+            Assert.IsNull(fooProperty.Xml);
+        }
+
+
+        private void XmlSerializerTestCode()
+        {
+            var types = new System.Collections.Generic.List<System.Type>();
+            types.Add(typeof(WithoutXmlAttributesDefined));
+            var serializer = XmlSerializer.FromTypes(types.ToArray()).First();
+            var testObject = new WithoutXmlAttributesDefined();
+            testObject.Foo = "stringvalue";
+            testObject.StringArray = new string[] { "S1" };
+            testObject.IntArray = new int[] { 1 };
+            testObject.DoubleArray = new double[] { 1 };
+            testObject.DecimalArray = new decimal[] { 1 };
+            testObject.InternalItem = new WithoutXmlAttributesDefined.WithoutXmlAttributeItem[] { new WithoutXmlAttributesDefined.WithoutXmlAttributeItem() { Name = "Test" } };
+
+            var sio = new System.IO.StringWriter();
+            serializer.Serialize(sio, testObject);
+            sio.ToString();
+        }
+    }
+}

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.Net4.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.Net4.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
@@ -91,6 +92,7 @@
     <Compile Include="Generation\KnownTypeGenerationTests.cs" />
     <Compile Include="Generation\TypeMappingsTests.cs" />
     <Compile Include="Generation\XmlDocTests.cs" />
+    <Compile Include="Generation\XmlObjectTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
     <Compile Include="Validation\LineInformationTest.cs" />

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Generation\KnownTypeGenerationTests.cs" />
     <Compile Include="Generation\TypeMappingsTests.cs" />
     <Compile Include="Generation\XmlDocTests.cs" />
+    <Compile Include="Generation\XmlObjectTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
     <Compile Include="Validation\LineInformationTest.cs" />

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -185,6 +185,9 @@ namespace NJsonSchema.Generation
             if (RequiresSchemaReference(itemType, null))
                 return new JsonSchema4 { SchemaReference = schema };
 
+            if (Settings.GenerateXmlObject)
+                await GenerateXmlObjectForItemTypeAsync(itemType, schema);
+
             return schema;
         }
 
@@ -264,6 +267,90 @@ namespace NJsonSchema.Generation
             await GeneratePropertiesAndInheritanceAsync(type, schema, schemaResolver).ConfigureAwait(false);
             if (Settings.GenerateKnownTypes)
                 await GenerateKnownTypesAsync(type, schemaResolver).ConfigureAwait(false);
+
+            if (Settings.GenerateXmlObject)
+                await GenerateXmlObjectForTypeAsync(type, schema);
+        }
+
+        private async Task GenerateXmlObjectForTypeAsync(Type type, JsonSchema4 schema)
+        {
+            var attributes = type.GetTypeInfo().GetCustomAttributes();
+            if (attributes.Any())
+            {
+                dynamic xmlTypeAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlTypeAttribute");
+                if (xmlTypeAttribute != null)
+                {
+                    await GenerateXmlObjectAsync(xmlTypeAttribute.TypeName, xmlTypeAttribute.Namespace, false, false, schema);
+                }
+            }               
+        }
+
+        private async Task GenerateXmlObjectForItemTypeAsync(Type type, JsonSchema4 schema)
+        {
+           await GenerateXmlObjectAsync(type.Name, null, false, false, schema);
+        }
+
+        private async Task GenerateXmlObjectForPropertyAsync(Type type, string propertyName, IEnumerable<Attribute> attributes, JsonProperty propertySchema)
+        {
+            string xmlName = null;
+            string xmlNamespace = null;
+            bool xmlWrapped = false;
+
+            if (propertySchema.Type == JsonObjectType.Array)
+            {
+                dynamic xmlArrayAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlArrayAttribute");
+                if (xmlArrayAttribute != null)
+                {
+                    xmlName = xmlArrayAttribute.ElementName;
+                    xmlNamespace = xmlArrayAttribute.Namespace;
+                }
+
+                dynamic xmlArrayItemsAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlArrayItemAttribute");
+                if (xmlArrayItemsAttribute != null)
+                {
+                    var xmlItemName = xmlArrayItemsAttribute.ElementName;
+                    var xmlItemNamespace = xmlArrayItemsAttribute.Namespace;
+
+                    await GenerateXmlObjectAsync(xmlItemName, xmlItemNamespace, true, false, propertySchema.Item);
+                }
+
+                xmlWrapped = true;
+            }
+
+            dynamic xmlElementAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlElementAttribute");
+            if (xmlElementAttribute != null)
+            {
+                xmlName = xmlElementAttribute.ElementName;
+                xmlNamespace = xmlElementAttribute.Namespace;
+            }
+
+            dynamic xmlAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlAttributeAttribute");
+            if (xmlAttribute != null)
+            {
+                if(!String.IsNullOrEmpty(xmlAttribute.AttributeName))
+                    xmlName = xmlAttribute.AttributeName;
+                if (!String.IsNullOrEmpty(xmlAttribute.Namespace))
+                    xmlNamespace = xmlAttribute.Namespace;
+            }
+
+            if(!String.IsNullOrEmpty(xmlName) || xmlWrapped)
+                await GenerateXmlObjectAsync(xmlName, xmlNamespace, xmlWrapped, xmlAttribute != null ? true : false, propertySchema);
+        }
+
+        private async Task GenerateXmlObjectAsync(string name, string @namespace, bool wrapped, bool isAttribute, JsonSchema4 schema)
+        {
+            await Task.Factory.StartNew(() =>
+            {
+                schema.Xml = new JsonXmlObject()
+                {
+                    Name = name,
+                    Wrapped = wrapped,
+                    Namespace = @namespace,
+                    ParentSchema = schema,
+                    Attribute = isAttribute
+                };
+                return 1;
+            });
         }
 
         private async Task GeneratePropertiesAndInheritanceAsync(Type type, JsonSchema4 schema, JsonSchemaResolver schemaResolver)
@@ -441,6 +528,9 @@ namespace NJsonSchema.Generation
                 var propertyName = JsonReflectionUtilities.GetPropertyName(property, Settings.DefaultPropertyNameHandling);
                 if (parentSchema.Properties.ContainsKey(propertyName))
                     throw new InvalidOperationException("The JSON property '" + propertyName + "' is defined multiple times on type '" + parentType.FullName + "'.");
+
+                if (Settings.GenerateXmlObject)
+                    await GenerateXmlObjectForPropertyAsync(parentType, propertyName, attributes, jsonProperty);
 
                 parentSchema.Properties.Add(propertyName, jsonProperty);
 

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -41,6 +41,9 @@ namespace NJsonSchema.Generation
         /// <summary>Gets or sets a value indicating whether to generate schemas for types in <see cref="KnownTypeAttribute"/> attributes (default: true).</summary>
         public bool GenerateKnownTypes { get; set; } = true;
 
+        /// <summary>Gets or sets a value indicating whether to generate xmlObject representation for definitions (default: false).</summary>
+        public bool GenerateXmlObject { get; set; } = false;
+
         /// <summary>Gets or sets the property nullability handling.</summary>
         public NullHandling NullHandling { get; set; }
 

--- a/src/NJsonSchema/Infrastructure/XmlObjectExtension.cs
+++ b/src/NJsonSchema/Infrastructure/XmlObjectExtension.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NJsonSchema.Infrastructure
+{
+    /// <summary>
+    /// Extension methods to help out generating XMLObject structure to schema
+    /// </summary>
+    public static class XmlObjectExtension
+    {
+        /// <summary>
+        /// Generate XML object for a schema definition
+        /// </summary>
+        /// <param name="schema">The definition</param>
+        /// <param name="type">The type of the definition</param>
+        public static void GenerateXmlObjectForType(this JsonSchema4 schema, Type type)
+        {
+            var attributes = type.GetTypeInfo().GetCustomAttributes();
+            if (attributes.Any())
+            {
+                dynamic xmlTypeAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlTypeAttribute");
+                if (xmlTypeAttribute != null)
+                {
+                    GenerateXmlObject(xmlTypeAttribute.TypeName, xmlTypeAttribute.Namespace, false, false, schema);
+                }
+            }
+        }
+        /// <summary>
+        /// Generates XMLObject structure for an array with primitive types
+        /// </summary>
+        /// <param name="schema">The schema for the item</param>
+        /// <param name="type"></param>
+        public static void GenerateXmlObjectForItemType(this JsonSchema4 schema, Type type)
+        {
+            //Is done all the time for XML to be able to get type name as the element name
+            GenerateXmlObject(type.Name, null, false, false, schema);
+        }
+
+        /// <summary>
+        /// Generates XMLObject structure for a property
+        /// </summary>
+        /// <param name="propertySchema">The schema for the property</param>
+        /// <param name="type">The type</param>
+        /// <param name="propertyName">The property name</param>
+        /// <param name="attributes">Attributes that exists for the property</param>
+        public static void GenerateXmlObjectForProperty(this JsonProperty propertySchema, Type type, string propertyName, IEnumerable<Attribute> attributes)
+        {
+            string xmlName = null;
+            string xmlNamespace = null;
+            bool xmlWrapped = false;
+
+            if (propertySchema.Type == JsonObjectType.Array)
+            {
+                dynamic xmlArrayAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlArrayAttribute");
+                if (xmlArrayAttribute != null)
+                {
+                    xmlName = xmlArrayAttribute.ElementName;
+                    xmlNamespace = xmlArrayAttribute.Namespace;
+                }
+
+                dynamic xmlArrayItemsAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlArrayItemAttribute");
+                if (xmlArrayItemsAttribute != null)
+                {
+                    var xmlItemName = xmlArrayItemsAttribute.ElementName;
+                    var xmlItemNamespace = xmlArrayItemsAttribute.Namespace;
+
+                    GenerateXmlObject(xmlItemName, xmlItemNamespace, true, false, propertySchema.Item);
+                }
+
+                xmlWrapped = true;
+            }
+
+            dynamic xmlElementAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlElementAttribute");
+            if (xmlElementAttribute != null)
+            {
+                xmlName = xmlElementAttribute.ElementName;
+                xmlNamespace = xmlElementAttribute.Namespace;
+            }
+
+            dynamic xmlAttribute = attributes.TryGetIfAssignableTo("System.Xml.Serialization.XmlAttributeAttribute");
+            if (xmlAttribute != null)
+            {
+                if (!String.IsNullOrEmpty(xmlAttribute.AttributeName))
+                    xmlName = xmlAttribute.AttributeName;
+                if (!String.IsNullOrEmpty(xmlAttribute.Namespace))
+                    xmlNamespace = xmlAttribute.Namespace;
+            }
+
+            if (!String.IsNullOrEmpty(xmlName) || xmlWrapped)
+                GenerateXmlObject(xmlName, xmlNamespace, xmlWrapped, xmlAttribute != null ? true : false, propertySchema);
+        }
+
+        private static void GenerateXmlObject(string name, string @namespace, bool wrapped, bool isAttribute, JsonSchema4 schema)
+        {
+            schema.Xml = new JsonXmlObject()
+            {
+                Name = name,
+                Wrapped = wrapped,
+                Namespace = @namespace,
+                ParentSchema = schema,
+                Attribute = isAttribute
+            };
+        }
+
+    }
+}

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -458,7 +458,20 @@ namespace NJsonSchema
 
         /// <summary>Gets the xml object of the type. </summary>
         [JsonProperty("xml", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public JsonXmlObject Xml { get; set; }
+        public JsonXmlObject Xml {
+            get
+            {
+                return _xmlObject;
+            }
+            set
+            {
+                _xmlObject = value;
+                //_xmlObject.ParentSchema = this;
+            }
+        }
+
+        [JsonIgnore]
+        private JsonXmlObject _xmlObject;
 
         /// <summary>Gets the pattern properties of the type. </summary>
         [JsonIgnore]

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -456,6 +456,10 @@ namespace NJsonSchema
             }
         }
 
+        /// <summary>Gets the xml object of the type. </summary>
+        [JsonProperty("xml", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public JsonXmlObject Xml { get; set; }
+
         /// <summary>Gets the pattern properties of the type. </summary>
         [JsonIgnore]
         public IDictionary<string, JsonSchema4> PatternProperties

--- a/src/NJsonSchema/JsonXmlObject.cs
+++ b/src/NJsonSchema/JsonXmlObject.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 namespace NJsonSchema
 {
     /// <summary>A description of a JSON property of a JSON object. </summary>
-    public class JsonXmlObject : JsonSchema4
+    public class JsonXmlObject
     {
         private JsonSchema4 _parentSchema;
 
@@ -47,7 +47,7 @@ namespace NJsonSchema
 
         /// <summary>Gets the parent schema of the XML object schema. </summary>
         [JsonIgnore]
-        public override JsonSchema4 ParentSchema
+        public JsonSchema4 ParentSchema
         {
             get { return _parentSchema; }
             internal set

--- a/src/NJsonSchema/JsonXmlObject.cs
+++ b/src/NJsonSchema/JsonXmlObject.cs
@@ -1,0 +1,60 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonProperty.cs" company="NJsonSchema">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace NJsonSchema
+{
+    /// <summary>A description of a JSON property of a JSON object. </summary>
+    public class JsonXmlObject : JsonSchema4
+    {
+        private JsonSchema4 _parentSchema;
+
+        internal static JsonXmlObject FromJsonSchema(string name, JsonSchema4 type)
+        {
+            var data = JsonConvert.SerializeObject(type);
+            var xmlObject = JsonConvert.DeserializeObject<JsonXmlObject>(data);
+            xmlObject.Name = name;
+            return xmlObject;
+        }
+
+        /// <summary>Gets or sets the name of the xml object. </summary>
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string Name { get; internal set; }
+
+        /// <summary>Gets or sets if the array elements are going to be wrapped or not. </summary>
+        [JsonProperty("wrapped", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public bool Wrapped { get; internal set; }
+
+        /// <summary>Gets or sets the URL of the namespace definition. </summary>
+        [JsonProperty("namespace", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string Namespace { get; internal set; }
+
+        /// <summary>Gets or sets the prefix for the name. </summary>
+        [JsonProperty("prefix", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string Prefix { get; internal set; }
+
+        /// <summary>Gets or sets if the property definition translates into an attribute instead of an element. </summary>
+        [JsonProperty("attribute", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public bool Attribute { get; internal set; }
+
+        /// <summary>Gets the parent schema of the XML object schema. </summary>
+        [JsonIgnore]
+        public override JsonSchema4 ParentSchema
+        {
+            get { return _parentSchema; }
+            internal set
+            {
+                var initialize = _parentSchema == null;
+                _parentSchema = value;
+            }
+        }
+    }
+}

--- a/src/NJsonSchema/NJsonSchema.Net4.csproj
+++ b/src/NJsonSchema/NJsonSchema.Net4.csproj
@@ -72,6 +72,7 @@
     <Compile Include="JsonSchema4.Serialization.cs" />
     <Compile Include="JsonSchemaReferenceUtilities.cs" />
     <Compile Include="JsonSchemaResolver.cs" />
+    <Compile Include="JsonXmlObject.cs" />
     <Compile Include="NullHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyNameHandling.cs" />

--- a/src/NJsonSchema/NJsonSchema.Net4.csproj
+++ b/src/NJsonSchema/NJsonSchema.Net4.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Infrastructure\ReflectionExtensions.cs" />
     <Compile Include="Infrastructure\TypeNameStyle.cs" />
     <Compile Include="Infrastructure\XmlDocumentationExtensions.cs" />
+    <Compile Include="Infrastructure\XmlObjectExtension.cs" />
     <Compile Include="ISchemaNameGenerator.cs" />
     <Compile Include="ITypeNameGenerator.cs" />
     <Compile Include="JsonFormatStrings.cs" />

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Converters\JsonInheritanceConverter.cs" />
     <Compile Include="ISchemaNameGenerator.cs" />
     <Compile Include="JsonReferenceResolver.cs" />
+    <Compile Include="JsonXmlObject.cs" />
     <Compile Include="PropertyNameHandling.cs" />
     <Compile Include="EnumHandling.cs" />
     <Compile Include="Infrastructure\DynamicApis.cs" />

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Annotations\MultipleOfAttribute.cs" />
     <Compile Include="Collections\ObservableDictionary.cs" />
     <Compile Include="Converters\JsonInheritanceConverter.cs" />
+    <Compile Include="Infrastructure\XmlObjectExtension.cs" />
     <Compile Include="ISchemaNameGenerator.cs" />
     <Compile Include="JsonReferenceResolver.cs" />
     <Compile Include="JsonXmlObject.cs" />


### PR DESCRIPTION
Hi Rico,
As we discussed in the issue(https://github.com/NSwag/NSwag/issues/508) regarding support for xmlObject.
I have done the changes from the XMLSerializer:s point of view and tried to map it against the Swagger spec:
http://swagger.io/specification/#xmlObject

Can you have a look at my changes and give feedback?

I need to run some tests from NSwag to get the full file running, so i can really verify it in Swagger UI.
Or is there anything in NJsonSchema solution that can generate a full Swagger JSON?

This is my first pull request, so please let me know if i'm doing something wrong.

/Emil

Feedback (rsuter): 

- [x] **Can we create a second class with your new code and use the class in the JsonSchemaGenerator?**
-- Ok, i moved it to an extension, the same way as you have done with the XML docs. Please have a look what you think.
--- Yes, this is very good.
- [x] **I haven't tested the code, but I think the XML object is always created. Is this correct? Can we change the code, so that the XML object is only created if it really contains additional information?**
-- Response: Only for line items where it is needed to generate the <type></type> all the time, if the attributes are used to decorate the array property they are called afterward. Can you point in code, just so i do not misunderstand you?
--- It seems ok for me, will do some tests with the Swagger generator later...
- [x] **Rename GenerateXmlObject to GenerateXmlObjects**
-- Why do you want to have it in plural? It's only one xmlObject created per schema instance...
--- Because it can potentially generate multiple XML objects (for sub-/property schemas)
- [ ] **Why inherits JsonXmlObject from JsonSchema4?**
-- That is true, i reverse engineered your JsonProperty class and try to keep as close to that one as possible. This is changed now.
--- Why does it even need more properties than (name, namespace, prefix, attribute, wrapped) or a base class? I don't see why it has to inherit from JsonProperty or JsonSchema4...
- [ ] **ParentSchema should be set in the setter of the XmlObject property of JsonSchema4, this way it is always set even if a schema is manually created in code.**
-- I get a lot of tests failing when doing that, i need to look into why. I checked it in with it commented out.
--- Maybe you need a null check?
- [x] **Maybe the call to GenerateXmlObjectForItemTypeAsync must be before RequiresSchemaReference?**
-- I have moved it, I don't see the full impact of it though, have not full understanding of the impact.
--- Because a schema reference is needed (and if evaluates to true) then the XML object is not generated...
- [x] **Why are all the methods async? Creating a new XML object should not be created in a task (it is CPU-bound). I think we should remove the async part of the methods - except if we have I/O somewhere in the code (i.e. loading a remote xml file?)?**
-- True, I have changed that.
--- Thanks