### PR TITLE
Change Uri type mapping to be nullable

### DIFF
--- a/src/NJsonSchema/Generation/JsonObjectTypeDescription.cs
+++ b/src/NJsonSchema/Generation/JsonObjectTypeDescription.cs
@@ -76,7 +76,7 @@ namespace NJsonSchema.Generation
                 return new JsonObjectTypeDescription(JsonObjectType.String, false, false, JsonFormatStrings.TimeSpan);
 
             if (type == typeof(Uri))
-                return new JsonObjectTypeDescription(JsonObjectType.String, false, false, JsonFormatStrings.Uri);
+                return new JsonObjectTypeDescription(JsonObjectType.String, allowsNull, false, JsonFormatStrings.Uri);
 
             if (type == typeof(byte))
                 return new JsonObjectTypeDescription(JsonObjectType.Integer, false, false, JsonFormatStrings.Byte);


### PR DESCRIPTION
This seems to only affect schemas generated with `NullHandling.Swagger`. Previously fields of type `Uri` were unconditionally marked as Required. This change makes them not required by default.

This is needed because C#'s `Uri` is a reference type, which allows null values. I've checked over the other mappings in this function and it looks like only `Uri` was incorrectly described as non-nullable.