### PR TITLE
Fix for 324 - Exception when generating schema on types that inherit a known type

### DIFF
--- a/src/NJsonSchema.Tests/Generation/KnownTypeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/KnownTypeGenerationTests.cs
@@ -20,11 +20,11 @@ namespace NJsonSchema.Tests.Generation
         {
         }
 
-        public class Pen
+        public class Pen : WritingInstrument
         {
         }
 
-        public class Pencil
+        public class Pencil : WritingInstrument
         {
         }
 

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json.Linq;
 using NJsonSchema.Annotations;
 using NJsonSchema.Converters;
 using NJsonSchema.Infrastructure;
+using System.Runtime.Serialization;
 
 namespace NJsonSchema.Generation
 {
@@ -303,7 +304,7 @@ namespace NJsonSchema.Generation
 
         private async Task GenerateKnownTypesAsync(Type type, JsonSchemaResolver schemaResolver)
         {
-            foreach (dynamic knownTypeAttribute in type.GetTypeInfo().GetCustomAttributes().Where(a => a.GetType().Name == "KnownTypeAttribute"))
+            foreach (dynamic knownTypeAttribute in type.GetTypeInfo().GetCustomAttributes(false).Where(a => a.GetType().Name == nameof(KnownTypeAttribute)))
             {
                 if (knownTypeAttribute.Type != null)
                     await AddKnownTypeAsync(knownTypeAttribute.Type, schemaResolver);

--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -274,7 +274,7 @@ namespace NJsonSchema.Infrastructure
         {
             var name = GetMemberElementName(member);
             var result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']");
-            return result.OfType<XElement>().First();
+            return result.OfType<XElement>().FirstOrDefault();
         }
 
         private static XElement GetXmlDocumentation(this ParameterInfo parameter, XDocument xml)
@@ -287,7 +287,7 @@ namespace NJsonSchema.Infrastructure
             else
                 result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']/param[@name='{parameter.Name}']");
 
-            return result.OfType<XElement>().First();
+            return result.OfType<XElement>().FirstOrDefault();
         }
 
         private static string RemoveLineBreakWhiteSpaces(string documentation)


### PR DESCRIPTION
When generating additional known types, the code was intending to look at classes that have the KnownType attribute set explicitly (not inherited).
 - Made fix to not look into inherited classes for the known type static method. 
- Updated tests to expose this problem/fix
- Avoided some exceptions that were getting swallowed finding xml documentation. It was making it more difficult to debug and was a minor change with no behavioral side effects i could think of.