### PR TITLE
Fix for inheritance of abstract properties and ContractResolver that suppresses properties

### DIFF
--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NJsonSchema.Generation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NJsonSchema.Tests.Generation
+{
+    [TestClass]
+    public class ContractResolverTests
+    {
+        [TestMethod]
+        public async Task Properties_should_match_custom_resolver()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<Person>(new JsonSchemaGeneratorSettings
+            {
+                ContractResolver = new OnlyWritableCamelCaseContractResolver()
+            });
+
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.IsTrue(schema.Properties.ContainsKey("firstName"));
+            Assert.AreEqual("firstName", schema.Properties["firstName"].Name);
+
+            Assert.IsFalse(schema.Properties.ContainsKey("nameLength"));
+        }
+
+        public class OnlyWritableCamelCaseContractResolver : CamelCasePropertyNamesContractResolver
+        {
+            protected override Newtonsoft.Json.Serialization.JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                var prop = base.CreateProperty(member, memberSerialization);
+                if (memberSerialization == MemberSerialization.OptOut)
+                {
+                    var jAttribute = member.GetCustomAttribute<JsonPropertyAttribute>(true);
+                    if (!prop.Writable && jAttribute == null)
+                        prop.ShouldSerialize = o => false;
+                }
+
+                return prop;
+            }
+        }
+
+        public class Person
+        {
+            public string FirstName { get; set; }
+            public int NameLength => FirstName.Length;
+        }
+    }
+}

--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.Generation;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -19,7 +21,7 @@ namespace NJsonSchema.Tests.Generation
         {
             var schema = await JsonSchema4.FromTypeAsync<Person>(new JsonSchemaGeneratorSettings
             {
-                ContractResolver = new OnlyWritableCamelCaseContractResolver()
+                ContractResolver = new CustomContractResolver()
             });
 
             var data = schema.ToJson();
@@ -29,20 +31,19 @@ namespace NJsonSchema.Tests.Generation
             Assert.AreEqual("firstName", schema.Properties["firstName"].Name);
 
             Assert.IsFalse(schema.Properties.ContainsKey("nameLength"));
+
+            Assert.IsTrue(schema.Properties.ContainsKey("location"));
+            Assert.AreEqual(schema.Properties["location"].Type, JsonObjectType.String | JsonObjectType.Null, 
+                "Location is resolved to a string contract because it has a type converter");
         }
 
-        public class OnlyWritableCamelCaseContractResolver : CamelCasePropertyNamesContractResolver
+        public class CustomContractResolver : CamelCasePropertyNamesContractResolver
         {
             protected override Newtonsoft.Json.Serialization.JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
             {
                 var prop = base.CreateProperty(member, memberSerialization);
-                if (memberSerialization == MemberSerialization.OptOut)
-                {
-                    var jAttribute = member.GetCustomAttribute<JsonPropertyAttribute>(true);
-                    if (!prop.Writable && jAttribute == null)
-                        prop.ShouldSerialize = o => false;
-                }
-
+                if (!prop.Writable && member.GetCustomAttribute<JsonPropertyAttribute>(true) == null)
+                    prop.ShouldSerialize = o => false;
                 return prop;
             }
         }
@@ -51,6 +52,43 @@ namespace NJsonSchema.Tests.Generation
         {
             public string FirstName { get; set; }
             public int NameLength => FirstName.Length;
+            public LocationPath Location { get; set; }
+        }
+
+        /// <summary>
+        /// A class that with a custom converter could serialize to a string
+        /// </summary>
+        [TypeConverter(typeof(StringConverter<LocationPath>))]
+        public class LocationPath : IStringConvertable
+        {
+            public ICollection<string> Path { get; set; } = new List<string>();
+
+            public string StringValue
+            {
+                get => string.Join("/", Path);
+                set => Path = new List<string>(value.Split('/'));
+            }
+
+            public override string ToString() => StringValue;
+        }
+
+        interface IStringConvertable
+        {
+            string StringValue { get; set; }
+            string ToString();
+        }
+
+        class StringConverter<T> : TypeConverter where T : IStringConvertable, new()
+        {
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) 
+                => sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
+
+            public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+            {
+                if (value is string)
+                    return new T() { StringValue = value.ToString() };
+                return base.ConvertFrom(context, culture, value);
+            }
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.Generation;
@@ -108,17 +109,19 @@ namespace NJsonSchema.Tests.Generation
             var data = schema.ToJson();
 
             //// Assert
-            Assert.AreEqual(3, schema.Properties.Count);
+            Assert.AreEqual(4, schema.Properties.Count);
         }
 
-        public class AA
+        public abstract class AA
         {
             public string FirstName { get; set; }
+            public abstract int Age { get; set; }
         }
 
         public class BB : AA
         {
             public string LastName { get; set; }
+            public override int Age { get; set; }
         }
 
         public class CC : BB

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\NJsonSchema.Tests.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,6 +69,7 @@
     <Compile Include="Conversion\SchemaReferenceTests.cs" />
     <Compile Include="Conversion\ArrayTypeToSchemaTests.cs" />
     <Compile Include="Generation\AnnotationsGenerationTests.cs" />
+    <Compile Include="Generation\ContractResolverTests.cs" />
     <Compile Include="Generation\DataToJsonSchemaGeneratorTests.cs" />
     <Compile Include="Generation\EnumListTests.cs" />
     <Compile Include="Generation\ExcplicitInterfacePropertyTests.cs" />

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -308,7 +308,9 @@ namespace NJsonSchema.Generation
             foreach (var property in objectContract.Properties)
             {
                 var propertyInfo = propertiesAndFields.FirstOrDefault(p => p.Name == property.UnderlyingName);
-                await LoadPropertyOrFieldAsync(property, propertyInfo, type, objectContract, schema, schemaResolver).ConfigureAwait(false);
+
+                if (!schema.Properties.ContainsKey(property.PropertyName) && property.ShouldSerialize?.Invoke(null) != false)
+                    await LoadPropertyOrFieldAsync(property, propertyInfo, type, objectContract, schema, schemaResolver).ConfigureAwait(false);
             }
 
 


### PR DESCRIPTION
- fixed logic for which properties should be included in schema
- added test for custom contract resolver
- fixed issue with inheritance with an abstract property
- suppress warnings for xml comments in test project