### PR TITLE
Added ability to create external references (issue #337)

### DIFF
--- a/src/NJsonSchema.Tests/Schema/JsonPathUtilitiesGetObjectFromJsonPathTests.cs
+++ b/src/NJsonSchema.Tests/Schema/JsonPathUtilitiesGetObjectFromJsonPathTests.cs
@@ -94,5 +94,23 @@ namespace NJsonSchema.Tests.Schema
             //// Assert
             Assert.AreEqual(foundObject, objectToSearch);
         }
+
+        [TestMethod]
+        public async Task When_object_is_in_external_file_then_path_should_be_built_correctly()
+        {
+            //// Arrange
+            var schemaToReference = new JsonSchema4 {DocumentPath = "some_schema.json"};
+            var referencingSchema = new JsonSchema4
+            {
+                DocumentPath = "other_schema.json",
+                SchemaReference = schemaToReference
+            };
+
+            //// Act
+            var result = referencingSchema.ToJson();
+
+            //// Assert
+            Assert.IsTrue(result.Contains("some_schema.json#"));
+        }
     }
 }

--- a/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
+++ b/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
@@ -59,7 +59,18 @@ namespace NJsonSchema
 
             var schema = obj as JsonSchema4;
             if (schema != null && schema.SchemaReference != null)
-                schema.SchemaReferencePath = JsonPathUtilities.GetJsonPath(rootObject, schema.SchemaReference.ActualSchema);
+            {
+                if (schema.DocumentPath == schema.SchemaReference.DocumentPath)
+                {
+                    schema.SchemaReferencePath = JsonPathUtilities.GetJsonPath(rootObject, schema.SchemaReference.ActualSchema);
+                }
+                else
+                {
+                    var externalReference = schema.SchemaReference;
+                    var externalReferenceRoot = externalReference.FindRootParent();
+                    schema.SchemaReferencePath = externalReference.DocumentPath + JsonPathUtilities.GetJsonPath(externalReferenceRoot, externalReference);
+                }
+            }
 
             if (obj is IDictionary)
             {


### PR DESCRIPTION
Accounts for different document paths and enables to create external references manually as requested in #337, by specifying DocumentPath on the reference schema, which differs from the referencing schema. Usage example is in the test.