### PR TITLE
Use custom contract resolver overrides for Dictionary and Array contracts 

### DIFF
--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -57,9 +57,9 @@ namespace NJsonSchema.Tests.Generation
             protected override JsonContract CreateContract(Type objectType)
             {
                 JsonContract contract = base.CreateContract(objectType);
-
                 // by default a type that can convert to string and that is also an enum will have an array contract, but serialize to a string!. fix  this
-                if (contract is JsonArrayContract && typeof(IEnumerable).IsAssignableFrom(objectType) && CanNonSystemTypeDescriptorConvertString(objectType, out var converter))
+                if (contract is JsonArrayContract && typeof(IEnumerable).IsAssignableFrom(objectType) 
+                    && CanNonSystemTypeDescriptorConvertString(objectType))
                     contract = CreateStringContract(objectType);
 
                 return contract;
@@ -70,10 +70,9 @@ namespace NJsonSchema.Tests.Generation
             "System.ComponentModel.ReferenceConverter",
             "System.ComponentModel.CollectionConverter" });
 
-            public static bool CanNonSystemTypeDescriptorConvertString(Type type, out TypeConverter typeConverter)
+            public static bool CanNonSystemTypeDescriptorConvertString(Type type)
             {
-                typeConverter = TypeDescriptor.GetConverter(type);
-
+                var typeConverter = TypeDescriptor.GetConverter(type);
                 // use the objectType's TypeConverter if it has one and can convert to a string
                 if (typeConverter != null)
                 {
@@ -83,7 +82,6 @@ namespace NJsonSchema.Tests.Generation
                 }
                 return false;
             }
-
         }
 
         public class Person

--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.Generation;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -33,10 +34,16 @@ namespace NJsonSchema.Tests.Generation
             Assert.IsFalse(schema.Properties.ContainsKey("nameLength"));
 
             Assert.IsTrue(schema.Properties.ContainsKey("location"));
-            Assert.AreEqual(schema.Properties["location"].Type, JsonObjectType.String | JsonObjectType.Null,
+            Assert.AreEqual(JsonObjectType.String | JsonObjectType.Null, schema.Properties["location"].Type,
                 "Location is resolved to a string contract because it has a type converter");
         }
 
+        /// <summary>
+        /// A contract resolver that
+        ///  - camel cases properties
+        ///  - does not serialize properties that are read only. 
+        ///  - overrides the array contract if it has a string type converter
+        /// </summary>
         public class CustomContractResolver : CamelCasePropertyNamesContractResolver
         {
             protected override Newtonsoft.Json.Serialization.JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
@@ -46,6 +53,37 @@ namespace NJsonSchema.Tests.Generation
                     prop.ShouldSerialize = o => false;
                 return prop;
             }
+
+            protected override JsonContract CreateContract(Type objectType)
+            {
+                JsonContract contract = base.CreateContract(objectType);
+
+                // by default a type that can convert to string and that is also an enum will have an array contract, but serialize to a string!. fix  this
+                if (contract is JsonArrayContract && typeof(IEnumerable).IsAssignableFrom(objectType) && CanNonSystemTypeDescriptorConvertString(objectType, out var converter))
+                    contract = CreateStringContract(objectType);
+
+                return contract;
+            }
+
+            static HashSet<string> _systemConverters = new HashSet<string>(new[] {
+            "System.ComponentModel.ComponentConverter",
+            "System.ComponentModel.ReferenceConverter",
+            "System.ComponentModel.CollectionConverter" });
+
+            public static bool CanNonSystemTypeDescriptorConvertString(Type type, out TypeConverter typeConverter)
+            {
+                typeConverter = TypeDescriptor.GetConverter(type);
+
+                // use the objectType's TypeConverter if it has one and can convert to a string
+                if (typeConverter != null)
+                {
+                    Type converterType = typeConverter.GetType();
+                    if (!_systemConverters.Contains(converterType.FullName) && converterType != typeof(TypeConverter))
+                        return typeConverter.CanConvertTo(typeof(string));
+                }
+                return false;
+            }
+
         }
 
         public class Person
@@ -56,10 +94,11 @@ namespace NJsonSchema.Tests.Generation
         }
 
         /// <summary>
-        /// A class that with a custom converter could serialize to a string
+        /// A class that with a custom converter could serialize to a string.
+        /// NOTE: The default contract resolver would resolve this as an array contract because it implements IEnumerable
         /// </summary>
         [TypeConverter(typeof(StringConverter<LocationPath>))]
-        public class LocationPath : IStringConvertable
+        public class LocationPath : IStringConvertable, IEnumerable<string>
         {
             public ICollection<string> Path { get; set; } = new List<string>();
 
@@ -68,6 +107,9 @@ namespace NJsonSchema.Tests.Generation
                 get { return string.Join("/", Path); ; }
                 set { Path = new List<string>(value.Split('/')); }
             }
+
+            public IEnumerator<string> GetEnumerator() => Path.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => Path.GetEnumerator();
 
             public override string ToString() => StringValue;
         }

--- a/src/NJsonSchema/Generation/JsonObjectTypeDescription.cs
+++ b/src/NJsonSchema/Generation/JsonObjectTypeDescription.cs
@@ -94,10 +94,10 @@ namespace NJsonSchema.Generation
             if (IsFileType(type))
                 return new JsonObjectTypeDescription(JsonObjectType.File, allowsNull);
 
-            if (IsDictionaryType(type))
+            if (IsDictionaryType(type) && contract is JsonDictionaryContract)
                 return new JsonObjectTypeDescription(JsonObjectType.Object, allowsNull, true);
 
-            if (IsArrayType(type))
+            if (IsArrayType(type) && contract is JsonArrayContract)
                 return new JsonObjectTypeDescription(JsonObjectType.Array, allowsNull);
 
             if (type.Name == "Nullable`1")


### PR DESCRIPTION
Changes
- added test for custom contract resolver that overrides default array contract
- only treat as array or dictionary when current NJsonSchema logic and contract resolver agree

The serialization by json.net in [regards to dictionaries and arrays](http://www.newtonsoft.com/json/help/html/SerializationGuide.htm#Breakdown) is not always desired. There are some cases that NJsonSchema differs (e.g. when you have extended a dictionary and added a property). When using both json.net and NJSonSchema and customizing serialization behavior, the contract resolver is a way to that both serialization and schema generation can be customized to do something differently.

These changes works towards customization being treated the same way for serialization and schema generation. Further changes should be made so that the custom treating of objects (e.g. dictionaries) by schema and code generation is done via custom contract revolvers rather than separate logic. 